### PR TITLE
fix[52] : download multiple corection du Filtrage des fichiers par extension

### DIFF
--- a/dev/src/Form/SearchFormType.php
+++ b/dev/src/Form/SearchFormType.php
@@ -98,7 +98,7 @@ class SearchFormType extends AbstractType
         ])
         ->add('sequencing', SearchType::class, [ 
             'required' => false,
-            'label' => 'Type file',
+            'label' => 'Sequencing Type file',
             'attr' => [
                 'placeholder' => 'png, fastq...'
             ]


### PR DESCRIPTION
J’ai renommé le label de recherche en “Sequencing type file” pour être plus clair.
Ensuite, j’ai ajouté un filtrage par extension lors de l’export ZIP (ex: .csv, .txt, .json).
Le filtre est maintenant appliqué au moment de l’ajout du fichier dans le ZIP, pour tous les types (sequencing, drugs, phenotype).
Seuls les fichiers dont le nom se termine réellement par l’extension demandée sont inclus.