### PR TITLE
Mise en place du CRUD pour les types de méthodes de sequençage

### DIFF
--- a/dev/src/Controller/MethodSequencingTypeController.php
+++ b/dev/src/Controller/MethodSequencingTypeController.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\MethodSequencingType;
+use App\Form\MethodSequencingTypeFormType;
+use App\Repository\MethodSequencingTypeRepository;
+use App\Repository\MethodSequencingTypeRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use FOS\ElasticaBundle\Finder\PaginatedFinderInterface;
+use Knp\Component\Pager\PaginatorInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class MethodSequencingTypeController extends AbstractController
+{
+    public function __construct(
+        #[Autowire(service: MethodSequencingTypeRepository::class)]
+        private MethodSequencingTypeRepositoryInterface $methodSequencingTypeRepository,
+        private PaginatorInterface $paginator,
+        private readonly PaginatedFinderInterface $finder
+    ) {
+    }
+
+    #[Route(path: 'strains/page_methodsequencingtypes', name: 'page_methodsequencingtypes')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function showPage(Request $request, EntityManagerInterface $em, Security $security): Response
+    {
+        $methodSequencingTypeAdd = $this->createForm(MethodSequencingTypeFormType::class);
+
+        // même logique que ton controller : addForm() retourne un Form (soumis ou non)
+        $methodSequencingTypeAdd = $this->addForm($request, $em);
+
+        $allTypes = $this->methodSequencingTypeRepository->findBy([], ['id' => 'DESC'], 10000);
+
+        return $this->render('methodSequencingType/main.html.twig', [
+            'methodSequencingTypeForm' => $methodSequencingTypeAdd->createView(),
+            'methodSequencingTypes' => $allTypes,
+        ]);
+    }
+
+    #[Route(path: 'strains/method_sequencing_type/ajout', name: 'add_method_sequencing_type')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function addForm(Request $request, EntityManagerInterface $em): Form
+    {
+        $type = new MethodSequencingType();
+
+        $form = $this->createForm(MethodSequencingTypeFormType::class, $type);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($type);
+            $em->flush();
+            return $form;
+        }
+
+        return $form;
+    }
+
+    #[Route(path: 'strains/method_sequencing_type/ajout/response', name: 'add_method_sequencing_type_response')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function addResponse(Request $request, EntityManagerInterface $em): Response
+    {
+        $type = new MethodSequencingType();
+
+        $form = $this->createForm(MethodSequencingTypeFormType::class, $type);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($type);
+            $em->flush();
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        return $this->render('methodSequencingType/create.html.twig', [
+            'methodSequencingTypeForm' => $form->createView(),
+        ]);
+    }
+
+    #[Route('strains/method_sequencing_type/edit/{id}', name: 'edit_method_sequencing_type')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function edit(
+        MethodSequencingType $methodSequencingType,
+        Request $request,
+        EntityManagerInterface $em,
+        Security $security
+    ): Response
+    {
+        if (!$security->isGranted('ROLE_ADMIN')) {
+            $this->addFlash('error', 'You do not have permission to edit a method sequencing type.');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        $form = $this->createForm(MethodSequencingTypeFormType::class, $methodSequencingType);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($methodSequencingType);
+            $em->flush();
+
+            $this->addFlash('success', 'Method sequencing type "' . $methodSequencingType->getName() . '" modified with success!');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        return $this->render('methodSequencingType/edit.html.twig', [
+            'methodSequencingTypeForm' => $form->createView(),
+        ]);
+    }
+
+    #[Route('method-sequencing-types/duplicate/{id}', name: 'duplicate_method_sequencing_type')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function duplicate(MethodSequencingType $methodSequencingType, EntityManagerInterface $em, Security $security): Response
+    {
+        try {
+            if (!$security->isGranted('ROLE_ADMIN')) {
+                $this->addFlash('error', 'You do not have permission to duplicate a method sequencing type.');
+                return $this->redirectToRoute('page_methodsequencingtypes');
+            }
+
+            $clone = new MethodSequencingType();
+            $clone->setName($methodSequencingType->getName());
+
+            $em->persist($clone);
+            $em->flush();
+
+            $this->addFlash('success', 'Method sequencing type "' . $clone->getName() . '" duplicated successfully!');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Error occurred while duplicating the method sequencing type.');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+    }
+
+    #[Route('/strains/method_sequencing_type/delete/{id}', name: 'delete_method_sequencing_type', methods: ['POST','GET'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function delete(MethodSequencingType $methodSequencingType, EntityManagerInterface $em): Response
+    {
+        // Bloqué si au moins un Sequencing utilise ce type (relation sequencing.name -> MethodSequencingType)
+        $rows = $em->createQuery(
+            'SELECT ms.id
+            FROM App\Entity\MethodSequencing ms
+            WHERE ms.name = :mst'
+        )
+        ->setParameter('mst', $methodSequencingType)
+        ->setMaxResults(2000)
+        ->getScalarResult();
+
+
+        $sequencingIds = array_map(fn(array $r) => (string) $r['id'], $rows);
+
+        if (!empty($sequencingIds)) {
+            $this->addFlash(
+                'error',
+                sprintf(
+                    'Cannot delete MethodSequencingType (ID: %d, Name: "%s") because it is associated with the following sequencing IDs: %s.',
+                    $methodSequencingType->getId(),
+                    $methodSequencingType->getName(),
+                    implode(', ', $sequencingIds)
+                )
+            );
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        $em->remove($methodSequencingType);
+        $em->flush();
+
+        $this->addFlash(
+            'success',
+            sprintf(
+                'MethodSequencingType (ID: %d, Name: "%s") has been successfully deleted.',
+                $methodSequencingType->getId(),
+                $methodSequencingType->getName()
+            )
+        );
+
+        return $this->redirectToRoute('page_methodsequencingtypes');
+    }
+
+    #[Route('/method-sequencing-types/delete-multiple', name: 'delete_multiple_method_sequencing_types', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function deleteMultiple(Request $request, EntityManagerInterface $em): Response
+    {
+        $ids = $request->request->all('selected_method_sequencing_types');
+
+        if (!is_array($ids) || empty($ids)) {
+            $this->addFlash('error', 'No method sequencing type selected.');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        $types = $em->getRepository(MethodSequencingType::class)->findBy(['id' => $ids]);
+
+        if (!$types) {
+            $this->addFlash('error', 'No method sequencing type found for deletion.');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        $detailsDeleted = [];
+        $detailsBlocked = [];
+
+        foreach ($types as $type) {
+            // ✅ Bloqué si lié à MethodSequencing (table "sequencing")
+            $rows = $em->createQuery(
+                'SELECT ms.id
+                FROM App\Entity\MethodSequencing ms
+                WHERE ms.name = :mst'
+            )
+                ->setParameter('mst', $type)
+                ->setMaxResults(2000)
+                ->getScalarResult();
+
+            $sequencingIds = array_map(fn(array $r) => (string) $r['id'], $rows);
+
+            if (!empty($sequencingIds)) {
+                $detailsBlocked[] = sprintf(
+                    '[MethodSequencingType ID: %d - Name: %s → Linked Sequencing IDs: %s]',
+                    $type->getId(),
+                    $type->getName(),
+                    implode(', ', $sequencingIds)
+                );
+                continue;
+            }
+
+            $detailsDeleted[] = sprintf('[MethodSequencingType ID: %d - Name: %s]', $type->getId(), $type->getName());
+            $em->remove($type);
+        }
+
+        if (!empty($detailsDeleted)) {
+            $em->flush();
+            $this->addFlash('success', sprintf(
+                '%d method sequencing type(s) successfully deleted: %s',
+                count($detailsDeleted),
+                implode(', ', $detailsDeleted)
+            ));
+        }
+
+        if (!empty($detailsBlocked)) {
+            $this->addFlash(
+                'error',
+                'Unable to delete the following method sequencing type(s) because they are linked to sequencing records: '
+                . implode(', ', $detailsBlocked)
+            );
+        }
+
+        return $this->redirectToRoute('page_methodsequencingtypes');
+    }
+}

--- a/dev/src/Form/MethodSequencingType.php
+++ b/dev/src/Form/MethodSequencingType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\MethodSequencingType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MethodSequencingTypeFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'MethodSequencingType',
+                'required' => true,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => MethodSequencingType::class,
+        ]);
+    }
+}

--- a/dev/templates/methodSequencingType/_filter_form_datatable_methodsequencingtype.html.twig
+++ b/dev/templates/methodSequencingType/_filter_form_datatable_methodsequencingtype.html.twig
@@ -1,0 +1,19 @@
+<div id="menu-container">
+    <button id="menu-button">☰ Filter Columns</button>
+
+    <div id="filter-menu" class="filter-menu">
+        <label>Show : </label>
+
+        <!-- ✅ Checkbox All -->
+        <label>
+            <input type="checkbox" id="toggle-all-columns" checked>
+            <b>All column</b>
+        </label>
+        <hr>
+        
+        <label><input type="checkbox" class="toggle-column" data-column="0" checked> Selection</label>
+        <label><input type="checkbox" class="toggle-column" data-column="1" checked> ID</label>
+        <label><input type="checkbox" class="toggle-column" data-column="2" checked> Type</label>
+    </div>
+</div>
+

--- a/dev/templates/methodSequencingType/_form.html.twig
+++ b/dev/templates/methodSequencingType/_form.html.twig
@@ -1,0 +1,6 @@
+{{ form_start(methodSequencingTypeForm) }}
+  {{ form_row(methodSequencingTypeForm.name) }}
+  <button type="submit" class="btn-form">
+    {{ button_label|default('Add sequencing method') }}
+  </button>
+{{ form_end(methodSequencingTypeForm) }}

--- a/dev/templates/methodSequencingType/create.html.twig
+++ b/dev/templates/methodSequencingType/create.html.twig
@@ -1,0 +1,11 @@
+
+        {% block body %}
+            <main class="container">
+                <section class="row">
+                    <div class="col-12">
+                        <h1>Add a new Sequencing method</h1>
+                        {% include "methodSequencingType/_form.html.twig" %}
+                    </div>
+                </section>
+            </main>
+        {% endblock %}

--- a/dev/templates/methodSequencingType/edit.html.twig
+++ b/dev/templates/methodSequencingType/edit.html.twig
@@ -1,0 +1,13 @@
+
+{% extends 'layout.html.twig' %}
+
+{% block body %}
+<main class="container">
+    <section class="row">
+        <div class="col-12">
+            <h1>Modifie a Phenotype</h1>
+            {% include "methodSequencingType/_form.html.twig" with {'button_label': 'Modifie'} %}
+        </div>
+    </section>
+</main>
+{% endblock %}

--- a/dev/templates/methodSequencingType/list.html.twig
+++ b/dev/templates/methodSequencingType/list.html.twig
@@ -1,0 +1,106 @@
+{# Font Awesome (optionnel) #}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+
+{# DataTables CSS #}
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" />
+<link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.dataTables.min.css" />
+
+{# jQuery #}
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
+{# DataTables core #}
+<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+
+{# DataTables Buttons #}
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.print.min.js"></script>
+
+{# Dépendances export Excel/PDF #}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
+
+<form id="multi-action-form" method="post">
+    <div id="data-table-wrapper" class="sticky-wrapper">
+        <table id="data-table-method-sequencing-types" class="display datatableComponent nowrap" style="visibility: hidden;">
+            <thead>
+                <tr>
+                    <th><input type="checkbox" id="select-all" /></th>
+                    <th>ID</th>
+                    <th>Type</th>
+                    <th data-column="duplicate" class="no-sort"></th>
+                    <th data-column="edit" class="no-sort"></th>
+                    <th data-column="delete" class="no-sort"></th>
+                </tr>
+            </thead>
+            <tbody>
+                {# variable attendue: methodSequencingTypes (ou adapte si tu passes "types") #}
+                {% for type in methodSequencingTypes %}
+                    <tr>
+                        <td>
+                            <input type="checkbox"
+                                   name="selected_method_sequencing_types[]"
+                                   value="{{ type.id }}"
+                                   class="select-checkbox" />
+                        </td>
+                        <td>{{ type.id }}</td>
+                        <td style="background:none !important; background-color:transparent !important;">
+                            {{ type.name }}
+                        </td>
+
+                        <td>
+                            <a href="{{ path('duplicate_method_sequencing_type', {id: type.id}) }}"
+                               class="button-crud"
+                               title="Copy">
+                                <i class="fa-solid fa-copy"></i>
+                            </a>
+                        </td>
+
+                        <td>
+                            <a href="{{ path('edit_method_sequencing_type', {id: type.id}) }}"
+                               class="button-crud"
+                               title="Modifie">
+                                <i class="fa-solid fa-pen-to-square"></i>
+                            </a>
+                        </td>
+
+                        <td>
+                            <a href="{{ path('delete_method_sequencing_type', {id: type.id}) }}"
+                               class="delete-link button-crud"
+                               title="Delete"
+                               onclick="return confirm('Do you really want to delete ?');">
+                                <i class="fa-solid fa-trash"></i>
+                            </a>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <input type="hidden" name="action" value="" />
+
+    <button id="btn-delete-multiple"
+            type="submit"
+            formaction="{{ path('delete_multiple_method_sequencing_types') }}"
+            onclick="this.form.action.value='delete'"
+            class="btn btn-danger"
+            style="margin-top: 10px; display: none;">
+        Delete selected
+    </button>
+</form>
+
+{% if app.session.flashbag.has('warning') %}
+<script>
+    document.querySelectorAll('.delete-link').forEach(function(link) {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            var confirmDelete = confirm("{{ app.session.flashbag.get('warning')[0] }}");
+            if (confirmDelete) {
+                window.location.href = this.href + '?confirm=yes';
+            }
+        });
+    });
+</script>
+{% endif %}

--- a/dev/templates/methodSequencingType/main.html.twig
+++ b/dev/templates/methodSequencingType/main.html.twig
@@ -1,0 +1,28 @@
+{% extends 'layout.html.twig' %}
+
+{% block body %}
+  <div id="global">
+
+    {% if 'ROLE_ADMIN' in app.user.roles %}
+      <div id="form">
+        {% include 'methodSequencingType/create.html.twig' %}
+      </div>
+    {% endif %}
+
+    <div id="list">
+      <div id="filter">
+        {% include 'methodSequencingType/_filter_form_datatable_methodsequencingtype.html.twig' %}
+      </div>
+
+      <div id="message">
+        {% include './message.html.twig' %}
+      </div>
+
+      <div id="table">
+        {% include 'methodSequencingType/list.html.twig' %}
+      </div>
+    </div>
+
+    <br />
+  </div>
+{% endblock %}

--- a/dev/templates/navbar.html.twig
+++ b/dev/templates/navbar.html.twig
@@ -19,7 +19,8 @@
     'page_plasmyds',
     'page_drugs',
     'page_publications',
-    'page_phenotypetypes'
+    'page_phenotypetypes',
+    'page_methodsequencingtypes'
 ] %}
 
 <body>
@@ -42,6 +43,7 @@
                     {{ nav.navItem(currentRoute, 'page_publications', 'Publication', '', false) }}
                     {% if 'ROLE_ADMIN' in app.user.roles %}
                         {{ nav.navItem(currentRoute, 'page_phenotypetypes', 'Phenotype', '', true) }}
+                        {{ nav.navItem(currentRoute, 'page_methodsequencingtypes', 'Sequencing method', '', true) }}
                     {% endif %}
                 </ul>
             </li>


### PR DESCRIPTION
Méthode de séquençage 

- Implémentation complète du CRUD (liste, ajout, modification, duplication, suppression)
- Sécurisation des routes avec ROLE_ADMIN
- Ajout d’un contrôle empêchant la suppression si le type est lié à des enregistrements de séquençage
- Intégration des vues Twig (main, form, list)