### PR TITLE
Favoris et unite de concentration mr

### DIFF
--- a/dev/assets/styles/app.css
+++ b/dev/assets/styles/app.css
@@ -701,6 +701,35 @@ thead {
    CSS specifique pour la DATATABLE de strain
 =========================================================== */
 
+.favorite-form {
+    display: inline;
+}
+
+.favorite-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    margin-left: 6px;
+    cursor: pointer;
+}
+
+.star {
+    font-size: 20px;
+    transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.star.active {
+    color: #f5b301; /* jaune propre */
+}
+
+.star.disabled {
+    color: #ccc;
+}
+
+.favorite-btn:hover .star {
+    transform: scale(1.2);
+}
+
 .dt-highlight {
     background-color: #ffeeba !important;
 }

--- a/dev/migrations/Version20260225123232.php
+++ b/dev/migrations/Version20260225123232.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260225123232 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add concentration_unit + is_favorite and fix unsigned compatibility';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // 1️⃣ Nouvelle colonne
+        $this->addSql('ALTER TABLE drug_resistance_on_strain ADD concentration_unit VARCHAR(50) DEFAULT NULL');
+
+        // 2️⃣ Aligner method_sequencing_type.id en INT UNSIGNED
+        $this->addSql('ALTER TABLE method_sequencing_type CHANGE id id INT UNSIGNED AUTO_INCREMENT NOT NULL');
+
+        // 3️⃣ Aligner sequencing.id et sequencing.name_id en INT UNSIGNED
+        $this->addSql('ALTER TABLE sequencing 
+            CHANGE id id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+            CHANGE size_file size_file INT DEFAULT NULL,
+            CHANGE name_id name_id INT UNSIGNED DEFAULT NULL
+        ');
+
+        // 4️⃣ FK sample → user
+        $this->addSql('CREATE INDEX IDX_F10B76C3A76ED395 ON sample (user_id)');
+        $this->addSql('ALTER TABLE sample ADD CONSTRAINT FK_F10B76C3A76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
+
+        // 5️⃣ Favoris
+        $this->addSql('ALTER TABLE strain ADD is_favorite TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE drug_resistance_on_strain DROP concentration_unit');
+
+        $this->addSql('ALTER TABLE method_sequencing_type CHANGE id id INT UNSIGNED AUTO_INCREMENT NOT NULL');
+
+        $this->addSql('ALTER TABLE sample DROP FOREIGN KEY FK_F10B76C3A76ED395');
+        $this->addSql('DROP INDEX IDX_F10B76C3A76ED395 ON sample');
+
+        $this->addSql('ALTER TABLE sequencing 
+            CHANGE id id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+            CHANGE size_file size_file BIGINT DEFAULT NULL,
+            CHANGE name_id name_id INT UNSIGNED DEFAULT NULL
+        ');
+
+        $this->addSql('ALTER TABLE strain DROP is_favorite');
+    }
+}

--- a/dev/src/Controller/MethodSequencingTypeController.php
+++ b/dev/src/Controller/MethodSequencingTypeController.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\MethodSequencingType;
+use App\Form\MethodSequencingTypeFormType;
+use App\Repository\MethodSequencingTypeRepository;
+use App\Repository\MethodSequencingTypeRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use FOS\ElasticaBundle\Finder\PaginatedFinderInterface;
+use Knp\Component\Pager\PaginatorInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class MethodSequencingTypeController extends AbstractController
+{
+    public function __construct(
+        #[Autowire(service: MethodSequencingTypeRepository::class)]
+        private MethodSequencingTypeRepositoryInterface $methodSequencingTypeRepository,
+        private PaginatorInterface $paginator,
+        private readonly PaginatedFinderInterface $finder
+    ) {
+    }
+
+    #[Route(path: 'strains/page_methodsequencingtypes', name: 'page_methodsequencingtypes')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function showPage(Request $request, EntityManagerInterface $em, Security $security): Response
+    {
+        $methodSequencingTypeAdd = $this->createForm(MethodSequencingTypeFormType::class);
+
+        // même logique que ton controller : addForm() retourne un Form (soumis ou non)
+        $methodSequencingTypeAdd = $this->addForm($request, $em);
+
+        $allTypes = $this->methodSequencingTypeRepository->findBy([], ['id' => 'DESC'], 10000);
+
+        return $this->render('methodSequencingType/main.html.twig', [
+            'methodSequencingTypeForm' => $methodSequencingTypeAdd->createView(),
+            'methodSequencingTypes' => $allTypes,
+        ]);
+    }
+
+    #[Route(path: 'strains/method_sequencing_type/ajout', name: 'add_method_sequencing_type')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function addForm(Request $request, EntityManagerInterface $em): Form
+    {
+        $type = new MethodSequencingType();
+
+        $form = $this->createForm(MethodSequencingTypeFormType::class, $type);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($type);
+            $em->flush();
+            return $form;
+        }
+
+        return $form;
+    }
+
+    #[Route(path: 'strains/method_sequencing_type/ajout/response', name: 'add_method_sequencing_type_response')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function addResponse(Request $request, EntityManagerInterface $em): Response
+    {
+        $type = new MethodSequencingType();
+
+        $form = $this->createForm(MethodSequencingTypeFormType::class, $type);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($type);
+            $em->flush();
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        return $this->render('methodSequencingType/create.html.twig', [
+            'methodSequencingTypeForm' => $form->createView(),
+        ]);
+    }
+
+    #[Route('strains/method_sequencing_type/edit/{id}', name: 'edit_method_sequencing_type')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function edit(
+        MethodSequencingType $methodSequencingType,
+        Request $request,
+        EntityManagerInterface $em,
+        Security $security
+    ): Response
+    {
+        if (!$security->isGranted('ROLE_ADMIN')) {
+            $this->addFlash('error', 'You do not have permission to edit a method sequencing type.');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        $form = $this->createForm(MethodSequencingTypeFormType::class, $methodSequencingType);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($methodSequencingType);
+            $em->flush();
+
+            $this->addFlash('success', 'Method sequencing type "' . $methodSequencingType->getName() . '" modified with success!');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        return $this->render('methodSequencingType/edit.html.twig', [
+            'methodSequencingTypeForm' => $form->createView(),
+        ]);
+    }
+
+    #[Route('method-sequencing-types/duplicate/{id}', name: 'duplicate_method_sequencing_type')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function duplicate(MethodSequencingType $methodSequencingType, EntityManagerInterface $em, Security $security): Response
+    {
+        try {
+            if (!$security->isGranted('ROLE_ADMIN')) {
+                $this->addFlash('error', 'You do not have permission to duplicate a method sequencing type.');
+                return $this->redirectToRoute('page_methodsequencingtypes');
+            }
+
+            $clone = new MethodSequencingType();
+            $clone->setName($methodSequencingType->getName());
+
+            $em->persist($clone);
+            $em->flush();
+
+            $this->addFlash('success', 'Method sequencing type "' . $clone->getName() . '" duplicated successfully!');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Error occurred while duplicating the method sequencing type.');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+    }
+
+    #[Route('/strains/method_sequencing_type/delete/{id}', name: 'delete_method_sequencing_type', methods: ['POST','GET'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function delete(MethodSequencingType $methodSequencingType, EntityManagerInterface $em): Response
+    {
+        // Bloqué si au moins un Sequencing utilise ce type (relation sequencing.name -> MethodSequencingType)
+        $rows = $em->createQuery(
+            'SELECT ms.id
+            FROM App\Entity\MethodSequencing ms
+            WHERE ms.name = :mst'
+        )
+        ->setParameter('mst', $methodSequencingType)
+        ->setMaxResults(2000)
+        ->getScalarResult();
+
+
+        $sequencingIds = array_map(fn(array $r) => (string) $r['id'], $rows);
+
+        if (!empty($sequencingIds)) {
+            $this->addFlash(
+                'error',
+                sprintf(
+                    'Cannot delete MethodSequencingType (ID: %d, Name: "%s") because it is associated with the following sequencing IDs: %s.',
+                    $methodSequencingType->getId(),
+                    $methodSequencingType->getName(),
+                    implode(', ', $sequencingIds)
+                )
+            );
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        $em->remove($methodSequencingType);
+        $em->flush();
+
+        $this->addFlash(
+            'success',
+            sprintf(
+                'MethodSequencingType (ID: %d, Name: "%s") has been successfully deleted.',
+                $methodSequencingType->getId(),
+                $methodSequencingType->getName()
+            )
+        );
+
+        return $this->redirectToRoute('page_methodsequencingtypes');
+    }
+
+    #[Route('/method-sequencing-types/delete-multiple', name: 'delete_multiple_method_sequencing_types', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function deleteMultiple(Request $request, EntityManagerInterface $em): Response
+    {
+        $ids = $request->request->all('selected_method_sequencing_types');
+
+        if (!is_array($ids) || empty($ids)) {
+            $this->addFlash('error', 'No method sequencing type selected.');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        $types = $em->getRepository(MethodSequencingType::class)->findBy(['id' => $ids]);
+
+        if (!$types) {
+            $this->addFlash('error', 'No method sequencing type found for deletion.');
+            return $this->redirectToRoute('page_methodsequencingtypes');
+        }
+
+        $detailsDeleted = [];
+        $detailsBlocked = [];
+
+        foreach ($types as $type) {
+            // ✅ Bloqué si lié à MethodSequencing (table "sequencing")
+            $rows = $em->createQuery(
+                'SELECT ms.id
+                FROM App\Entity\MethodSequencing ms
+                WHERE ms.name = :mst'
+            )
+                ->setParameter('mst', $type)
+                ->setMaxResults(2000)
+                ->getScalarResult();
+
+            $sequencingIds = array_map(fn(array $r) => (string) $r['id'], $rows);
+
+            if (!empty($sequencingIds)) {
+                $detailsBlocked[] = sprintf(
+                    '[MethodSequencingType ID: %d - Name: %s → Linked Sequencing IDs: %s]',
+                    $type->getId(),
+                    $type->getName(),
+                    implode(', ', $sequencingIds)
+                );
+                continue;
+            }
+
+            $detailsDeleted[] = sprintf('[MethodSequencingType ID: %d - Name: %s]', $type->getId(), $type->getName());
+            $em->remove($type);
+        }
+
+        if (!empty($detailsDeleted)) {
+            $em->flush();
+            $this->addFlash('success', sprintf(
+                '%d method sequencing type(s) successfully deleted: %s',
+                count($detailsDeleted),
+                implode(', ', $detailsDeleted)
+            ));
+        }
+
+        if (!empty($detailsBlocked)) {
+            $this->addFlash(
+                'error',
+                'Unable to delete the following method sequencing type(s) because they are linked to sequencing records: '
+                . implode(', ', $detailsBlocked)
+            );
+        }
+
+        return $this->redirectToRoute('page_methodsequencingtypes');
+    }
+}

--- a/dev/src/Entity/DrugResistanceOnStrain.php
+++ b/dev/src/Entity/DrugResistanceOnStrain.php
@@ -44,6 +44,9 @@ class DrugResistanceOnStrain
     #[ORM\Column(type: 'datetime', nullable: true)]
     private ?\DateTimeInterface $date = null;
 
+    #[ORM\Column(length: 50, nullable: true)]
+    private ?string $concentrationUnit = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -156,6 +159,15 @@ class DrugResistanceOnStrain
         return $this;
     }
 
+    public function getConcentrationUnit(): ?string
+    {
+        return $this->concentrationUnit;
+    }
 
+    public function setConcentrationUnit(?string $unit): self
+    {
+        $this->concentrationUnit = $unit;
+        return $this;
+    }
 
 }

--- a/dev/src/Entity/MethodSequencing.php
+++ b/dev/src/Entity/MethodSequencing.php
@@ -46,7 +46,7 @@ class MethodSequencing
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $comment = null;
 
-    #[ORM\ManyToOne(targetEntity: Strain::class, inversedBy: 'MethodSequencing')]
+    #[ORM\ManyToOne(targetEntity: Strain::class, inversedBy: 'methodSequencing')]
     private Strain $strain;
 
     public function getId(): ?int

--- a/dev/src/Entity/Strain.php
+++ b/dev/src/Entity/Strain.php
@@ -125,6 +125,9 @@ class Strain
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $dateArchive = null;
 
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    private bool $isFavorite = false;
+
     public function __construct()
     {
         $this->drugResistanceOnStrain = new ArrayCollection();
@@ -602,6 +605,17 @@ class Strain
     {
         $this->dateArchive = $date;
 
+        return $this;
+    }
+
+    public function isFavorite(): bool
+    {
+        return $this->isFavorite;
+    }
+
+    public function setIsFavorite(bool $isFavorite): self
+    {
+        $this->isFavorite = $isFavorite;
         return $this;
     }
 

--- a/dev/src/Entity/User.php
+++ b/dev/src/Entity/User.php
@@ -2,6 +2,11 @@
 
 namespace App\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use App\Entity\Strain;
+use App\Entity\Sample;
+
 use App\Repository\UserRepository;
 use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
@@ -13,7 +18,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_EMAIL', fields: ['email'])]
 #[UniqueEntity(fields: ['email'], message: 'There is already an account with this email')]
-#[ORM\Table(name: '"user"', schema: 'public')]
+//#[ORM\Table(name: '"user"', schema: 'public')]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
@@ -48,10 +53,23 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
     private ?DateTimeImmutable $createdAt = null;
 
+    /**
+     * @var Collection<int, Strain>
+     */
+    #[ORM\OneToMany(mappedBy: 'createdBy', targetEntity: Strain::class)]
+    private Collection $strain;
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
+        $this->strain = new ArrayCollection();
+        $this->samples = new ArrayCollection();
     }
+
+    /**
+     * @var Collection<int, Sample>
+     */
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: Sample::class)]
+    private Collection $samples;
 
     public function getId(): ?int
     {
@@ -173,6 +191,16 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->isAccess = $isVerified;
 
         return $this;
+    }
+
+    public function getStrains(): Collection
+    {
+        return $this->strain;
+    }
+
+    public function getSamples(): Collection
+    {
+        return $this->samples;
     }
 
 

--- a/dev/src/Form/DrugOnFormType.php
+++ b/dev/src/Form/DrugOnFormType.php
@@ -13,6 +13,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Vich\UploaderBundle\Form\Type\VichFileType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 
 class DrugOnFormType extends AbstractType
 {
@@ -30,9 +32,29 @@ class DrugOnFormType extends AbstractType
                     'placeholder' => 'Concentration',
                 ],
             ])
+            ->add('concentration', options:[
+                'label' => 'Concentration',
+                'attr' => ['placeholder' => 'Concentration'],
+            ])
+            ->add('concentrationUnit', ChoiceType::class, [
+                'label' => 'Unit',
+                'required' => true, // ou false si tu veux
+                'placeholder' => 'Select unit',
+                'choices' => [
+                    'µg/mL' => 'ug/mL',
+                    'mg/mL' => 'mg/mL',
+                    'g/mL'  => 'g/mL',
+                    'ng/mL' => 'ng/mL',
+                    // ajoute ce dont tu as besoin
+                ],
+            ])
             ->add('resistant', CheckboxType::class, options:[
                 'label' => 'Resistant',
                 'required' => false
+            ])
+            ->add('date', DateType::class, [
+                'widget' => 'single_text',
+                'required' => false,
             ]);
 
             if ($options['is_update']) {

--- a/dev/src/Form/MethodSequencingType.php
+++ b/dev/src/Form/MethodSequencingType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\MethodSequencingType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MethodSequencingTypeFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'MethodSequencingType',
+                'required' => true,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => MethodSequencingType::class,
+        ]);
+    }
+}

--- a/dev/templates/methodSequencingType/_filter_form_datatable_methodsequencingtype.html.twig
+++ b/dev/templates/methodSequencingType/_filter_form_datatable_methodsequencingtype.html.twig
@@ -1,0 +1,19 @@
+<div id="menu-container">
+    <button id="menu-button">☰ Filter Columns</button>
+
+    <div id="filter-menu" class="filter-menu">
+        <label>Show : </label>
+
+        <!-- ✅ Checkbox All -->
+        <label>
+            <input type="checkbox" id="toggle-all-columns" checked>
+            <b>All column</b>
+        </label>
+        <hr>
+        
+        <label><input type="checkbox" class="toggle-column" data-column="0" checked> Selection</label>
+        <label><input type="checkbox" class="toggle-column" data-column="1" checked> ID</label>
+        <label><input type="checkbox" class="toggle-column" data-column="2" checked> Type</label>
+    </div>
+</div>
+

--- a/dev/templates/methodSequencingType/_form.html.twig
+++ b/dev/templates/methodSequencingType/_form.html.twig
@@ -1,0 +1,6 @@
+{{ form_start(methodSequencingTypeForm) }}
+  {{ form_row(methodSequencingTypeForm.name) }}
+  <button type="submit" class="btn-form">
+    {{ button_label|default('Add sequencing method') }}
+  </button>
+{{ form_end(methodSequencingTypeForm) }}

--- a/dev/templates/methodSequencingType/create.html.twig
+++ b/dev/templates/methodSequencingType/create.html.twig
@@ -1,0 +1,11 @@
+
+        {% block body %}
+            <main class="container">
+                <section class="row">
+                    <div class="col-12">
+                        <h1>Add a new Sequencing method</h1>
+                        {% include "methodSequencingType/_form.html.twig" %}
+                    </div>
+                </section>
+            </main>
+        {% endblock %}

--- a/dev/templates/methodSequencingType/edit.html.twig
+++ b/dev/templates/methodSequencingType/edit.html.twig
@@ -1,0 +1,13 @@
+
+{% extends 'layout.html.twig' %}
+
+{% block body %}
+<main class="container">
+    <section class="row">
+        <div class="col-12">
+            <h1>Modifie a Phenotype</h1>
+            {% include "methodSequencingType/_form.html.twig" with {'button_label': 'Modifie'} %}
+        </div>
+    </section>
+</main>
+{% endblock %}

--- a/dev/templates/methodSequencingType/list.html.twig
+++ b/dev/templates/methodSequencingType/list.html.twig
@@ -1,0 +1,106 @@
+{# Font Awesome (optionnel) #}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+
+{# DataTables CSS #}
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" />
+<link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.dataTables.min.css" />
+
+{# jQuery #}
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
+{# DataTables core #}
+<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+
+{# DataTables Buttons #}
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.print.min.js"></script>
+
+{# Dépendances export Excel/PDF #}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
+
+<form id="multi-action-form" method="post">
+    <div id="data-table-wrapper" class="sticky-wrapper">
+        <table id="data-table-method-sequencing-types" class="display datatableComponent nowrap" style="visibility: hidden;">
+            <thead>
+                <tr>
+                    <th><input type="checkbox" id="select-all" /></th>
+                    <th>ID</th>
+                    <th>Type</th>
+                    <th data-column="duplicate" class="no-sort"></th>
+                    <th data-column="edit" class="no-sort"></th>
+                    <th data-column="delete" class="no-sort"></th>
+                </tr>
+            </thead>
+            <tbody>
+                {# variable attendue: methodSequencingTypes (ou adapte si tu passes "types") #}
+                {% for type in methodSequencingTypes %}
+                    <tr>
+                        <td>
+                            <input type="checkbox"
+                                   name="selected_method_sequencing_types[]"
+                                   value="{{ type.id }}"
+                                   class="select-checkbox" />
+                        </td>
+                        <td>{{ type.id }}</td>
+                        <td style="background:none !important; background-color:transparent !important;">
+                            {{ type.name }}
+                        </td>
+
+                        <td>
+                            <a href="{{ path('duplicate_method_sequencing_type', {id: type.id}) }}"
+                               class="button-crud"
+                               title="Copy">
+                                <i class="fa-solid fa-copy"></i>
+                            </a>
+                        </td>
+
+                        <td>
+                            <a href="{{ path('edit_method_sequencing_type', {id: type.id}) }}"
+                               class="button-crud"
+                               title="Modifie">
+                                <i class="fa-solid fa-pen-to-square"></i>
+                            </a>
+                        </td>
+
+                        <td>
+                            <a href="{{ path('delete_method_sequencing_type', {id: type.id}) }}"
+                               class="delete-link button-crud"
+                               title="Delete"
+                               onclick="return confirm('Do you really want to delete ?');">
+                                <i class="fa-solid fa-trash"></i>
+                            </a>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <input type="hidden" name="action" value="" />
+
+    <button id="btn-delete-multiple"
+            type="submit"
+            formaction="{{ path('delete_multiple_method_sequencing_types') }}"
+            onclick="this.form.action.value='delete'"
+            class="btn btn-danger"
+            style="margin-top: 10px; display: none;">
+        Delete selected
+    </button>
+</form>
+
+{% if app.session.flashbag.has('warning') %}
+<script>
+    document.querySelectorAll('.delete-link').forEach(function(link) {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            var confirmDelete = confirm("{{ app.session.flashbag.get('warning')[0] }}");
+            if (confirmDelete) {
+                window.location.href = this.href + '?confirm=yes';
+            }
+        });
+    });
+</script>
+{% endif %}

--- a/dev/templates/methodSequencingType/main.html.twig
+++ b/dev/templates/methodSequencingType/main.html.twig
@@ -1,0 +1,28 @@
+{% extends 'layout.html.twig' %}
+
+{% block body %}
+  <div id="global">
+
+    {% if 'ROLE_ADMIN' in app.user.roles %}
+      <div id="form">
+        {% include 'methodSequencingType/create.html.twig' %}
+      </div>
+    {% endif %}
+
+    <div id="list">
+      <div id="filter">
+        {% include 'methodSequencingType/_filter_form_datatable_methodsequencingtype.html.twig' %}
+      </div>
+
+      <div id="message">
+        {% include './message.html.twig' %}
+      </div>
+
+      <div id="table">
+        {% include 'methodSequencingType/list.html.twig' %}
+      </div>
+    </div>
+
+    <br />
+  </div>
+{% endblock %}

--- a/dev/templates/navbar.html.twig
+++ b/dev/templates/navbar.html.twig
@@ -19,7 +19,8 @@
     'page_plasmyds',
     'page_drugs',
     'page_publications',
-    'page_phenotypetypes'
+    'page_phenotypetypes',
+    'page_methodsequencingtypes'
 ] %}
 
 <body>
@@ -42,6 +43,7 @@
                     {{ nav.navItem(currentRoute, 'page_publications', 'Publication', '', false) }}
                     {% if 'ROLE_ADMIN' in app.user.roles %}
                         {{ nav.navItem(currentRoute, 'page_phenotypetypes', 'Phenotype', '', true) }}
+                        {{ nav.navItem(currentRoute, 'page_methodsequencingtypes', 'Sequencing method', '', true) }}
                     {% endif %}
                 </ul>
             </li>

--- a/dev/templates/plasmyd/_form.html.twig
+++ b/dev/templates/plasmyd/_form.html.twig
@@ -7,7 +7,7 @@
         {{ form_row(plasmydForm.comment) }}
 
         <button type="submit" class="btn-form">
-            {{ button_label | default('Add plasmyd') }}
+            {{ button_label | default('Add plasmid') }}
         </button>
 
     {{ form_end(plasmydForm) }}

--- a/dev/templates/strain/list.html.twig
+++ b/dev/templates/strain/list.html.twig
@@ -72,7 +72,19 @@
                                 <input type="checkbox" name="selected_strain[]" value="{{ strain.id }}" class="select-checkbox" />
                             </td>
                             <td class="id">{{strain.id}}</td>
-                            <td class="name">{{ strain.nameStrain is not null ? strain.nameStrain : '' }}</td>
+                            <td class="name">
+                                {{ strain.nameStrain ?? '' }}
+
+                                {% if strain.createdBy.id == app.user.id %}
+                                    <button 
+                                        class="favorite-btn"
+                                        data-id="{{ strain.id }}"
+                                    >
+                                        <span class="star {{ strain.isFavorite ? 'active' : '' }}">★</span>
+                                    </button>
+                                {% endif %}
+                            </td>
+
                             <td class="date">
                             {% if strain.date is not null %}
                                 {{strain.date|date("d/m/Y")}}
@@ -281,6 +293,8 @@
                                     data-info='
                                         name: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.drugResistance.name  : '--'}}
                                         concentration: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.concentration : '--'}}
+                                        concentration_unit: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.concentrationUnit : '--' }}
+                                        date: {{ strain.drugResistanceOnStrain|first and strain.drugResistanceOnStrain|first.date ? strain.drugResistanceOnStrain|first.date|date("Y-m-d") : "--" }}
                                         resistant: {{ strain.drugResistanceOnStrain|first ? (strain.drugResistanceOnStrain|first.resistant ? 'yes' : 'no') : '--' }}
                                         comment: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.comment   : '--'}}
                                         description: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.description  : '--'}}
@@ -290,6 +304,9 @@
                                     {% if strain.drugResistanceOnStrain is not empty %}
                                         {{strain.drugResistanceOnStrain[0].drugResistance.name}} <br>
                                         {{strain.drugResistanceOnStrain[0].concentration}}
+                                        {% if strain.drugResistanceOnStrain[0].concentrationUnit %}
+                                            {{ strain.drugResistanceOnStrain[0].concentrationUnit }}
+                                        {% endif %}
                                         {% if strain.drugResistanceOnStrain[0].resistant == 1 %}
                                             <a class="resistant-display-red"> resistante : &#9888; </a>
                                         {% else %}
@@ -618,3 +635,33 @@
 </script>
 {% endif %}
 
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+
+    document.querySelectorAll('.favorite-btn').forEach(button => {
+
+        button.addEventListener('click', function (e) {
+            e.preventDefault();
+
+            const strainId = this.dataset.id;
+            const star = this.querySelector('.star');
+
+            fetch(`/strain/${strainId}/favorite`, {
+                method: 'POST',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    star.classList.toggle('active', data.isFavorite);
+                }
+            });
+        });
+
+    });
+
+});
+</script>

--- a/dev/templates/strain/user_filter_button.html.twig
+++ b/dev/templates/strain/user_filter_button.html.twig
@@ -4,3 +4,16 @@
   🔍 Filter by : {{ user.firstname }} {{ user.lastname }}
 </button>
 
+{% if is_favorites %}
+    <button type="button"
+            class="btn btn-warning"
+            onclick="window.location.href='{{ path('page_strains') }}'">
+        ★ Showing Favorites (Click to reset)
+    </button>
+{% else %}
+    <button type="button"
+            class="btn btn-outline-warning"
+            onclick="window.location.href='{{ path('page_strains', { favorites: 1 }) }}'">
+        ★ My Favorites
+    </button>
+{% endif %}


### PR DESCRIPTION
J’ai corrigé les erreurs de mapping Doctrine (relations bidirectionnelles incohérentes entre Strain, MethodSequencing, Sample et User).
Les mappedBy / inversedBy sont maintenant correctement alignés et le schema:validate passe côté mapping.

Un problème SQL bloquait les clés étrangères (erreur 3780) à cause d’un décalage entre INT et INT UNSIGNED.
Les colonnes concernées ont été uniformisées en INT UNSIGNED dans la migration afin d’assurer la cohérence des FK.

La migration Version20260225123232.php ajoute désormais deux champs métier :

concentration_unit dans drug_resistance_on_strain

is_favorite dans strain

Les types SQL ont été harmonisés pour garantir la cohérence globale.
Sur une base propre, la migration passe sans ajustement manuel.

Partie Favoris

Implémentation du système de favoris sur les souches :

Ajout du champ isFavorite dans l’entité Strain

Création de la route toggle_favorite_strain (POST + JsonResponse)

Sécurisation : seule la souche appartenant à l’utilisateur peut être ajoutée ou retirée des favoris

Mise à jour de l’index Elasticsearch après modification

Côté interface :

Ajout d’un bouton étoile dans la liste des souches (visible uniquement si la souche appartient à l’utilisateur)

Mise en place d’un filtre favorites via paramètre ?favorites=1

Possibilité d’activer / désactiver l’affichage des favoris via le bouton dédié

Partie Drug / Concentration

Ajout des champs concentrationUnit et date dans DrugOnFormType

L’unité de concentration est intégrée dans l’affichage Twig (rendu visuel + data-info)

La date a été ajoutée dans le data-info pour exploitation côté modale / JS