### PR TITLE
U xmodal prelevement uniformisation css mr

### DIFF
--- a/dev/assets/app.js
+++ b/dev/assets/app.js
@@ -17,6 +17,7 @@ import './scriptJs/toggleColumns.js'
 import './scriptJs/confirmMultiDelete.js'
 import './scriptJs/patchCssDownloadMultiple.js'
 import './scriptJs/gridfixModifieStrainOverflowOnce.js'
+import './scriptJs/toggleCreateForm.js'
 
 
 

--- a/dev/assets/scriptJs/datatableComponent.js
+++ b/dev/assets/scriptJs/datatableComponent.js
@@ -73,6 +73,14 @@ function initDataTableWithFilters(tableId) {
         initComplete: function () {
             table.css('visibility', 'visible');
             $('#btn-delete-multiple').show(); // Si bouton présent
+            
+            // --- Partie 2 : On deplace length, filter et buttons dans une div au dessus de la table pour la fixer
+            $('#' + tableId + '_wrapper .dataTables_length, #' + tableId + '_wrapper .dataTables_filter, #' + tableId + '_wrapper .dt-buttons, .table-action-bar')
+            .appendTo('#table-header-toolbar');
+
+            // 🔽 Ajout : déplacer pagination + info dans le footer
+            $('#' + tableId + '_wrapper .dataTables_info, #' + tableId + '_wrapper .dataTables_paginate')
+            .appendTo('#table-controls-footer');
         }
     });
 

--- a/dev/assets/scriptJs/toggleCreateForm.js
+++ b/dev/assets/scriptJs/toggleCreateForm.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const toggleBtn = document.getElementById('toggleForm');
+    const formDiv = document.getElementById('form');
+    const closeBtn = document.getElementById('closeForm');
+
+    if (!toggleBtn || !formDiv || !closeBtn) {
+        return;
+    }
+
+    toggleBtn.addEventListener('click', () => {
+        formDiv.classList.remove('hidden');
+        formDiv.classList.add('show');
+        toggleBtn.style.display = 'none';
+    });
+
+    closeBtn.addEventListener('click', () => {
+        formDiv.classList.remove('show');
+        formDiv.classList.add('hidden');
+        toggleBtn.style.display = 'inline-block';
+    });
+});

--- a/dev/assets/styles/app.css
+++ b/dev/assets/styles/app.css
@@ -517,7 +517,7 @@ button.btn-form:hover,
 }
 
 #global #list #filter  .filter-menu.visible {
-    display: inline-block; /* Affiche le menu lorsque la classe "visible" est ajoutée */
+    display: block !important; /* Affiche le menu lorsque la classe "visible" est ajoutée */
     top : 100%; 
     background: #f1f1f1;
     left: 0;
@@ -562,6 +562,10 @@ button.btn-form:hover,
     background-color: #f9f9f9; /* Couleur de fond */
 }
 
+.filterComponent {
+    padding: 10px !important;
+}
+
 input[type="checkbox"] {
   accent-color: #3c546d;; /* couleur du togunderlinegle */
 }
@@ -571,18 +575,16 @@ input[type="checkbox"] {
 =========================================================== */
 
 #global #list #table {
-    margin-top : 10px; 
-    table-layout: fixed; /* Fixe la largeur des colonnes */
-    overflow-x: auto; 
-    overflow-y: scroll;
-    border-collapse: collapse;
+    margin-top: 10px;
+    overflow-x: auto;
+    overflow-y: visible;
     font-family: 'Arial', sans-serif;
     font-size: 14px;
     color: #333;
-    background-color: #ffffff !important; /* Fond blanc forcé */
+    background-color: #ffffff !important;
     margin-bottom: 20px;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-    height: 100%;
+    height: auto;
 }
 
 .sub-cell {

--- a/dev/src/Controller/SampleController.php
+++ b/dev/src/Controller/SampleController.php
@@ -169,6 +169,15 @@ class SampleController extends AbstractController
             $clone->setUnderLocalisation($sample->getUnderLocalisation());
             $clone->setGps($sample->getGps());
             $clone->setEnvironment($sample->getEnvironment());
+
+            $clone->setBioSample($sample->getBioSample());
+            $clone->setFarmLocation($sample->getFarmLocation());
+            $clone->setHospitalSampleType($sample->getHospitalSampleType());
+            $clone->setHospitalSite($sample->getHospitalSite());
+            $clone->setHospitalWard($sample->getHospitalWard());
+            $clone->setPatientContextType($sample->getPatientContextType());
+            $clone->setSource($sample->getSource());
+
             $clone->setOther($sample->getOther());
             $clone->setDescription($sample->getDescription());
             $clone->setComment($sample->getComment());

--- a/dev/src/Entity/Sample.php
+++ b/dev/src/Entity/Sample.php
@@ -7,6 +7,11 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\Collection;
 
+use App\Enum\HospitalSampleTypeEnum;
+use App\Enum\HospitalSiteEnum;
+use App\Enum\PatientContextTypeEnum;
+use App\Enum\SourceEnum;
+
 #[ORM\Entity(repositoryClass: SampleRepository::class)]
 class Sample
 {
@@ -55,26 +60,26 @@ class Sample
     #[ORM\JoinColumn(nullable: true)]
     private ?User $user = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
+   #[ORM\Column(length: 255, nullable: true)]
     private ?string $bioSample = null;
 
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $farmLocation = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $hospitalSampleType = null;
+    #[ORM\Column(enumType: HospitalSampleTypeEnum::class, nullable: true)]
+    private ?HospitalSampleTypeEnum $hospitalSampleType = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $hospitalSite = null;
+    #[ORM\Column(enumType: HospitalSiteEnum::class, nullable: true)]
+    private ?HospitalSiteEnum $hospitalSite = null;
 
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $hospitalWard = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $patientContextType = null;
+    #[ORM\Column(enumType: PatientContextTypeEnum::class, nullable: true)]
+    private ?PatientContextTypeEnum $patientContextType = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $source = null;
+    #[ORM\Column(enumType: SourceEnum::class, nullable: true)]
+    private ?SourceEnum $source = null;
 
     /**
      * @var Collection<int, Strain>
@@ -279,23 +284,23 @@ class Sample
         return $this;
     }
 
-    public function getHospitalSampleType(): ?string
+    public function getHospitalSampleType(): ?HospitalSampleTypeEnum
     {
         return $this->hospitalSampleType;
     }
 
-    public function setHospitalSampleType(?string $hospitalSampleType): static
+    public function setHospitalSampleType(?HospitalSampleTypeEnum $hospitalSampleType): static
     {
         $this->hospitalSampleType = $hospitalSampleType;
         return $this;
     }
 
-    public function getHospitalSite(): ?string
+    public function getHospitalSite(): ?HospitalSiteEnum
     {
         return $this->hospitalSite;
     }
 
-    public function setHospitalSite(?string $hospitalSite): static
+    public function setHospitalSite(?HospitalSiteEnum $hospitalSite): static
     {
         $this->hospitalSite = $hospitalSite;
         return $this;
@@ -312,23 +317,23 @@ class Sample
         return $this;
     }
 
-    public function getPatientContextType(): ?string
+    public function getPatientContextType(): ?PatientContextTypeEnum
     {
         return $this->patientContextType;
     }
 
-    public function setPatientContextType(?string $patientContextType): static
+    public function setPatientContextType(?PatientContextTypeEnum $patientContextType): static
     {
         $this->patientContextType = $patientContextType;
         return $this;
     }
 
-    public function getSource(): ?string
+    public function getSource(): ?SourceEnum
     {
         return $this->source;
     }
 
-    public function setSource(?string $source): static
+    public function setSource(?SourceEnum $source): static
     {
         $this->source = $source;
         return $this;

--- a/dev/src/Enum/HospitalSampleTypeEnum.php
+++ b/dev/src/Enum/HospitalSampleTypeEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enum;
+
+enum HospitalSampleTypeEnum: string
+{
+    case WARD_ENVIRONMENT = 'ward_environment';
+    case PATIENT = 'patient';
+}

--- a/dev/src/Enum/HospitalSiteEnum.php
+++ b/dev/src/Enum/HospitalSiteEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enum;
+
+enum HospitalSiteEnum: string
+{
+    case CENTRE = 'centre';
+    case EST = 'est';
+    case NORD = 'nord';
+    case SUD = 'sud';
+}

--- a/dev/src/Enum/PatientContextTypeEnum.php
+++ b/dev/src/Enum/PatientContextTypeEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enum;
+
+enum PatientContextTypeEnum: string
+{
+    case SCREENING = 'screening';
+    case INFECTION = 'infection';
+}

--- a/dev/src/Enum/SourceEnum.php
+++ b/dev/src/Enum/SourceEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enum;
+
+enum SourceEnum: string
+{
+    case FARM = 'farm';
+    case RHONE_RIVERBANK = 'Rhone_riverbank';
+    case HOSPITAL = 'hospital';
+    case SIAMU = 'SIAMU';
+}

--- a/dev/src/Form/SampleFormType.php
+++ b/dev/src/Form/SampleFormType.php
@@ -2,8 +2,13 @@
 
 namespace App\Form;
 
+use App\Enum\HospitalSampleTypeEnum;
+use App\Enum\HospitalSiteEnum;
+use App\Enum\PatientContextTypeEnum;
+use App\Enum\SourceEnum;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class SampleFormType extends AbstractType
@@ -37,6 +42,38 @@ class SampleFormType extends AbstractType
             ])
             ->add('environment', options:[
                 'label' => 'Environnement'
+            ])
+            ->add('bioSample', options:[
+                'label' => 'Bio Sample',
+                'required' => false
+            ])
+            ->add('farmLocation', options:[
+                'label' => 'Farm Location',
+                'required' => false
+            ])
+            ->add('hospitalSampleType', EnumType::class, options:[
+                'class' => HospitalSampleTypeEnum::class,
+                'label' => 'Hospital Sample Type',
+                'required' => false
+            ])
+            ->add('hospitalSite', EnumType::class, options:[
+                'class' => HospitalSiteEnum::class,
+                'label' => 'Hospital Site',
+                'required' => false
+            ])
+            ->add('hospitalWard', options:[
+                'label' => 'Hospital Ward',
+                'required' => false
+            ])
+            ->add('patientContextType', EnumType::class, options:[
+                'class' => PatientContextTypeEnum::class,
+                'label' => 'Patient Context Type',
+                'required' => false
+            ])
+            ->add('source', EnumType::class, options:[
+                'class' => SourceEnum::class,
+                'label' => 'Source',
+                'required' => false
             ])
             ->add('other', options:[
                 'label' => 'Other Sources'

--- a/dev/templates/collec/main.html.twig
+++ b/dev/templates/collec/main.html.twig
@@ -8,15 +8,17 @@
             </div>
         {% endif %}
         <div id="list">
-            <div id="filter">
+            <div id="filter" class="filterComponent">
                 {% include 'collec/_filter_form_datatable_collect.html.twig' %}
             </div>
             <div id="message">
                 {% include './message.html.twig' %}
             </div>
+             <div id="table-header-toolbar"></div>
             <div id="table">
                 {% include "collec/list.html.twig" %}
             </div>
+            <div id="table-controls-footer"></div>
         </div>
         <br></br>
     </div> 

--- a/dev/templates/drug/main.html.twig
+++ b/dev/templates/drug/main.html.twig
@@ -8,15 +8,17 @@
             </div>
         {% endif %}
         <div id="list">
-            <div id="filter">
+            <div id="filter" class="filterComponent">
                 {% include 'drug/_filter_form_datatable_drug.html.twig' %}
             </div>
             <div id="message">
                 {% include './message.html.twig' %}
             </div>
+            <div id="table-header-toolbar"></div>
             <div id="table">
                 {% include "drug/list.html.twig" %}
             </div>
+            <div id="table-controls-footer"></div>
         </div>
         <br></br>
     </div>  

--- a/dev/templates/methodSequencingType/main.html.twig
+++ b/dev/templates/methodSequencingType/main.html.twig
@@ -10,7 +10,7 @@
     {% endif %}
 
     <div id="list">
-      <div id="filter">
+      <div id="filter" class="filterComponent">
         {% include 'methodSequencingType/_filter_form_datatable_methodsequencingtype.html.twig' %}
       </div>
 
@@ -18,9 +18,14 @@
         {% include './message.html.twig' %}
       </div>
 
+      <div id="table-header-toolbar"></div>
+
       <div id="table">
         {% include 'methodSequencingType/list.html.twig' %}
       </div>
+
+      <div id="table-controls-footer"></div>
+
     </div>
 
     <br />

--- a/dev/templates/phenotypeType/main.html.twig
+++ b/dev/templates/phenotypeType/main.html.twig
@@ -10,7 +10,7 @@
     {% endif %}
 
     <div id="list">
-      <div id="filter">
+      <div id="filter" class="filterComponent">
         {% include 'phenotypeType/_filter_form_datatable_phenotypetype.html.twig' %}
       </div>
 
@@ -18,11 +18,15 @@
         {% include './message.html.twig' %}
       </div>
 
+      <div id="table-header-toolbar"></div>
+
       <div id="table">
         {% include 'phenotypeType/list.html.twig' %}
       </div>
-    </div>
 
+      <div id="table-controls-footer"></div>
+      
+    </div>
     <br />
   </div>
 {% endblock %}

--- a/dev/templates/plasmyd/main.html.twig
+++ b/dev/templates/plasmyd/main.html.twig
@@ -9,15 +9,17 @@
             </div>
         {% endif %}
         <div id="list">
-            <div id="filter">
+            <div id="filter" class="filterComponent">
                 {% include 'plasmyd/_filter_form_datatable_plasmyd.html.twig' %}
             </div>
             <div id="message">
                 {% include './message.html.twig' %}
             </div>
+            <div id="table-header-toolbar"></div>
             <div id="table">
                 {% include "plasmyd/list.html.twig" %}
             </div>
+            <div id="table-controls-footer"></div>
         </div>
         <br></br>
     </div>  

--- a/dev/templates/project/main.html.twig
+++ b/dev/templates/project/main.html.twig
@@ -7,15 +7,17 @@
                 </div>
             {% endif %}
             <div id="list">
-                <div id="filter">
+                <div id="filter" class="filterComponent">
                     {% include 'project/_filter_form_datatable_project.html.twig' %}
                 </div>
                 <div id="message">
                     {% include './message.html.twig' %}
                 </div>
+                <div id="table-header-toolbar"></div>
                 <div id="table">
                     {% include "project/list.html.twig" %}
                 </div>
+                <div id="table-controls-footer"></div>
             </div>
         <br></br>        
         </div>  

--- a/dev/templates/publication/main.html.twig
+++ b/dev/templates/publication/main.html.twig
@@ -7,15 +7,17 @@
                 </div>
             {% endif %}
             <div id="list">
-                <div id="filter">
+                <div id="filter" class="filterComponent">
                     {% include 'publication/_filter_form_datatable_publication.html.twig' %}
                 </div>
                 <div id="message">
                     {% include './message.html.twig' %}
                 </div>
+                <div id="table-header-toolbar"></div>
                 <div id="table">
                     {% include "publication/list.html.twig" %}
                 </div>
+                <div id="table-controls-footer"></div>
             </div>
         <br></br>        
         </div>  

--- a/dev/templates/sample/_form.html.twig
+++ b/dev/templates/sample/_form.html.twig
@@ -10,6 +10,16 @@
     {{ form_row(sampleForm.gps) }}
     {{ form_row(sampleForm.environment) }}
     {{ form_row(sampleForm.other) }}
+
+    {# nouveaux champs #}
+    {{ form_row(sampleForm.bioSample) }}
+    {{ form_row(sampleForm.farmLocation) }}
+    {{ form_row(sampleForm.hospitalSampleType) }}
+    {{ form_row(sampleForm.hospitalSite) }}
+    {{ form_row(sampleForm.hospitalWard) }}
+    {{ form_row(sampleForm.patientContextType) }}
+    {{ form_row(sampleForm.source) }}
+
     {{ form_row(sampleForm.description) }}
     {{ form_row(sampleForm.comment) }}
 

--- a/dev/templates/sample/list.html.twig
+++ b/dev/templates/sample/list.html.twig
@@ -37,6 +37,13 @@
                     <th>Under Localisation</th>
                     <th>GPS</th>
                     <th>Environnement</th>
+                    <th>Bio Sample</th>
+                    <th>Farm Location</th>
+                    <th>Hospital Sample Type</th>
+                    <th>Hospital Site</th>
+                    <th>Hospital Ward</th>
+                    <th>Patient Context Type</th>
+                    <th>Source</th>
                     <th>Other</th>
                     <th>Description</th>
                     <th>Comment</th>
@@ -62,6 +69,13 @@
                         <td>{{ sample.underLocalisation }}</td>
                         <td>{{ sample.gps }}</td>
                         <td>{{ sample.environment }}</td>
+                        <td>{{ sample.bioSample }}</td>
+                        <td>{{ sample.farmLocation }}</td>
+                        <td>{{ sample.hospitalSampleType ? sample.hospitalSampleType.value : '' }}</td>
+                        <td>{{ sample.hospitalSite ? sample.hospitalSite.value : '' }}</td>
+                        <td>{{ sample.hospitalWard }}</td>
+                        <td>{{ sample.patientContextType ? sample.patientContextType.value : '' }}</td>
+                        <td>{{ sample.source ? sample.source.value : '' }}</td>
                         <td>{{ sample.other }}</td>
                         <td>{{ sample.description }}</td>
                         <td>{{ sample.comment }}</td>

--- a/dev/templates/sample/main.html.twig
+++ b/dev/templates/sample/main.html.twig
@@ -12,7 +12,7 @@
         {% endif %}
 
         <div id="list">
-            <div id="filter">
+            <div id="filter" class="filterComponent">
                 {% include 'sample/_filter_form_datatable_sample.html.twig' %}
             </div>
 
@@ -20,9 +20,14 @@
                 {% include './message.html.twig' %}
             </div>
 
+            <div id="table-header-toolbar"></div>
+
             <div id="table">
                 {% include "sample/list.html.twig" %}
             </div>
+
+            <div id="table-controls-footer"></div>
+
         </div>
 
         <br>

--- a/dev/templates/sample/main.html.twig
+++ b/dev/templates/sample/main.html.twig
@@ -28,27 +28,4 @@
         <br>
     </div>
 
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const toggleBtn = document.getElementById('toggleForm');
-            const formDiv = document.getElementById('form');
-            const closeBtn = document.getElementById('closeForm');
-
-            if (!toggleBtn || !formDiv || !closeBtn) return;
-
-            // Ouvrir le formulaire avec le bouton +
-            toggleBtn.addEventListener('click', () => {
-                formDiv.classList.remove('hidden');
-                formDiv.classList.add('show');
-                toggleBtn.style.display = 'none';
-            });
-
-            // Fermer le formulaire avec le bouton -
-            closeBtn.addEventListener('click', () => {
-                formDiv.classList.remove('show');
-                formDiv.classList.add('hidden');
-                toggleBtn.style.display = 'inline-block';
-            });
-        });
-    </script>
 {% endblock %}

--- a/dev/templates/sample/main.html.twig
+++ b/dev/templates/sample/main.html.twig
@@ -3,21 +3,52 @@
 {% block body %}
     <div id="global">
         {% if 'ROLE_SEARCH' in app.user.roles or 'ROLE_ADMIN' in app.user.roles %}
-            <div id="form">
+            <button id="toggleForm">+</button>
+
+            <div id="form" class="hidden">
+                <button id="closeForm">-</button>
                 {% include "sample/create.html.twig" %}
             </div>
         {% endif %}
+
         <div id="list">
             <div id="filter">
                 {% include 'sample/_filter_form_datatable_sample.html.twig' %}
             </div>
+
             <div id="message">
                 {% include './message.html.twig' %}
             </div>
+
             <div id="table">
                 {% include "sample/list.html.twig" %}
             </div>
         </div>
-        <br></br>
-    </div>  
+
+        <br>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const toggleBtn = document.getElementById('toggleForm');
+            const formDiv = document.getElementById('form');
+            const closeBtn = document.getElementById('closeForm');
+
+            if (!toggleBtn || !formDiv || !closeBtn) return;
+
+            // Ouvrir le formulaire avec le bouton +
+            toggleBtn.addEventListener('click', () => {
+                formDiv.classList.remove('hidden');
+                formDiv.classList.add('show');
+                toggleBtn.style.display = 'none';
+            });
+
+            // Fermer le formulaire avec le bouton -
+            closeBtn.addEventListener('click', () => {
+                formDiv.classList.remove('show');
+                formDiv.classList.add('hidden');
+                toggleBtn.style.display = 'inline-block';
+            });
+        });
+    </script>
 {% endblock %}

--- a/dev/templates/strain/list.html.twig
+++ b/dev/templates/strain/list.html.twig
@@ -121,6 +121,15 @@
                                         localisation : {{ strain.prelevement ? strain.prelevement.localisation : "--" }}
                                         under-localisation : {{ strain.prelevement ? strain.prelevement.underLocalisation : "--" }}
                                         environment : {{ strain.prelevement ? strain.prelevement.environment : "--" }}
+                                        bio-sample : {{ strain.prelevement and strain.prelevement.bioSample ? strain.prelevement.bioSample : "--" }}
+                                        farm-location : {{ strain.prelevement and strain.prelevement.farmLocation ? strain.prelevement.farmLocation : "--" }}
+
+                                        hospital-sample-type : {{ strain.prelevement and strain.prelevement.hospitalSampleType ? strain.prelevement.hospitalSampleType.value : "--" }}
+                                        hospital-site : {{ strain.prelevement and strain.prelevement.hospitalSite ? strain.prelevement.hospitalSite.value : "--" }}
+                                        hospital-ward : {{ strain.prelevement and strain.prelevement.hospitalWard ? strain.prelevement.hospitalWard : "--" }}
+
+                                        patient-context-type : {{ strain.prelevement and strain.prelevement.patientContextType ? strain.prelevement.patientContextType.value : "--" }}
+                                        source : {{ strain.prelevement and strain.prelevement.source ? strain.prelevement.source.value : "--" }}
                                     '>
                                 {{ strain.prelevement ? strain.prelevement.name : '--' }}
                             </td>

--- a/dev/templates/strain/main.html.twig
+++ b/dev/templates/strain/main.html.twig
@@ -46,24 +46,4 @@
         <br></br>        
         </div>  
 
-
- <script>
-        const toggleBtn = document.getElementById('toggleForm');
-        const formDiv = document.getElementById('form');
-        const closeBtn = document.getElementById('closeForm');
-
-        // Ouvrir le formulaire avec le bouton +
-        toggleBtn.addEventListener('click', () => {
-            formDiv.classList.remove('hidden');
-            formDiv.classList.add('show');
-            toggleBtn.style.display = 'none';
-        });
-
-        // Fermer le formulaire avec le bouton -
-        closeBtn.addEventListener('click', () => {
-            formDiv.classList.remove('show');
-            formDiv.classList.add('hidden');
-            toggleBtn.style.display = 'inline-block';
-        });
-</script>
 {% endblock %}

--- a/dev/templates/user/main.html.twig
+++ b/dev/templates/user/main.html.twig
@@ -3,15 +3,17 @@
 {% block body %}
     <div id="global">
         <div id="list">
-            <div id="filter">
+            <div id="filter" class="filterComponent">
                 {% include 'user/_filter_form_datatable_user.html.twig' %}
             </div>
             <div id="message">
                 {% include './message.html.twig' %}
             </div>
+            <div id="table-header-toolbar"></div>
             <div id="table" class="table-user">
                 {% include "user/list.html.twig" %}
             </div>
+            <div id="table-controls-footer"></div>
         </div>
         <br>
     </div>


### PR DESCRIPTION
UXmodalPrelevementUniformisationCSS_MR

On a ajouté dans Prelevement / Sample un système pour afficher ou masquer le formulaire d’ajout directement dans la page. Un bouton + permet d’ouvrir le formulaire et un bouton − permet de le fermer. Le formulaire apparaît sans changer de page.

On a corrigé l’utilisation des enum dans le formulaire et dans l’affichage Twig. Les champs hospitalSampleType, hospitalSite, patientContextType et source sont maintenant correctement affichés en utilisant .value.

Dans le tableau Sample, on a ajouté l’affichage des nouveaux champs : bioSample, farmLocation, hospitalSampleType, hospitalSite, hospitalWard, patientContextType et source.

On a aussi corrigé la duplication d’un sample pour que ces nouvelles informations soient copiées lorsque l’on duplique un prélèvement.

Dans Strain, on a ajouté ces nouvelles informations dans le data-info du sample. Quand on clique sur un sample dans la table strain, la popup affiche maintenant aussi bioSample, farmLocation, hospitalSampleType, hospitalSite, hospitalWard, patientContextType et source.

On a ensuite amélioré l’interface des DataTables. Les éléments length, search et les boutons d’export sont déplacés dans un conteneur en haut (table-header-toolbar) et la pagination avec les informations sont déplacées dans un conteneur en bas (table-controls-footer). Cette structure sera utilisée pour les autres composants.

Enfin on a corrigé du CSS global des tables. La hauteur des tableaux est passée en height: auto pour éviter les grands espaces blancs inutiles sous les tables. On a aussi ajusté le style du filtre avec une classe filterComponent et corrigé l’affichage du menu filtre pour qu’il prenne toute la largeur quand il est visible.