### PR TITLE
Modal affichage fichier mr

### DIFF
--- a/dev/assets/app.js
+++ b/dev/assets/app.js
@@ -18,6 +18,7 @@ import './scriptJs/confirmMultiDelete.js'
 import './scriptJs/patchCssDownloadMultiple.js'
 import './scriptJs/gridfixModifieStrainOverflowOnce.js'
 import './scriptJs/toggleCreateForm.js'
+import './scriptJs/filePreviewModal.js'
 
 
 

--- a/dev/assets/app.js
+++ b/dev/assets/app.js
@@ -17,6 +17,7 @@ import './scriptJs/toggleColumns.js'
 import './scriptJs/confirmMultiDelete.js'
 import './scriptJs/patchCssDownloadMultiple.js'
 import './scriptJs/gridfixModifieStrainOverflowOnce.js'
+import './scriptJs/toggleCreateForm.js'
 
 
 

--- a/dev/assets/scriptJs/datatableComponent.js
+++ b/dev/assets/scriptJs/datatableComponent.js
@@ -73,6 +73,14 @@ function initDataTableWithFilters(tableId) {
         initComplete: function () {
             table.css('visibility', 'visible');
             $('#btn-delete-multiple').show(); // Si bouton présent
+            
+            // --- Partie 2 : On deplace length, filter et buttons dans une div au dessus de la table pour la fixer
+            $('#' + tableId + '_wrapper .dataTables_length, #' + tableId + '_wrapper .dataTables_filter, #' + tableId + '_wrapper .dt-buttons, .table-action-bar')
+            .appendTo('#table-header-toolbar');
+
+            // 🔽 Ajout : déplacer pagination + info dans le footer
+            $('#' + tableId + '_wrapper .dataTables_info, #' + tableId + '_wrapper .dataTables_paginate')
+            .appendTo('#table-controls-footer');
         }
     });
 

--- a/dev/assets/scriptJs/filePreviewModal.js
+++ b/dev/assets/scriptJs/filePreviewModal.js
@@ -1,0 +1,41 @@
+$(document).ready(function () {
+    const $modal = $('#filePreviewModal');
+    const $closeBtn = $('#file-preview-close');
+    const $overlay = $('.custom-modal-overlay');
+    const $title = $('#file-preview-title');
+    const $body = $('#file-preview-body');
+
+    $(document).on('click', '.open-file-modal', function (e) {
+        e.preventDefault();
+
+        const strainId = $(this).data('strain-id');
+        const type = $(this).data('type');
+
+        if (!strainId || !type) {
+            return;
+        }
+
+        $title.text(`Preview - ${type} - strain ${strainId}`);
+        $body.html('<p>Loading...</p>');
+        $modal.css('display', 'block');
+
+        $.ajax({
+            url: `/strain/${strainId}/file-preview/${type}`,
+            method: 'GET',
+            success: function (html) {
+                $body.html(html);
+            },
+            error: function () {
+                $body.html('<p>Erreur de chargement.</p>');
+            }
+        });
+    });
+
+    $closeBtn.on('click', function () {
+        $modal.hide();
+    });
+
+    $overlay.on('click', function () {
+        $modal.hide();
+    });
+});

--- a/dev/assets/scriptJs/toggleCreateForm.js
+++ b/dev/assets/scriptJs/toggleCreateForm.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const toggleBtn = document.getElementById('toggleForm');
+    const formDiv = document.getElementById('form');
+    const closeBtn = document.getElementById('closeForm');
+
+    if (!toggleBtn || !formDiv || !closeBtn) {
+        return;
+    }
+
+    toggleBtn.addEventListener('click', () => {
+        formDiv.classList.remove('hidden');
+        formDiv.classList.add('show');
+        toggleBtn.style.display = 'none';
+    });
+
+    closeBtn.addEventListener('click', () => {
+        formDiv.classList.remove('show');
+        formDiv.classList.add('hidden');
+        toggleBtn.style.display = 'inline-block';
+    });
+});

--- a/dev/assets/styles/app.css
+++ b/dev/assets/styles/app.css
@@ -505,6 +505,7 @@ button.btn-form:hover,
     transition: background-color 0.3s ease;
     position: relative; /* Positionne le bouton à l'intérieur du conteneur */
     z-index: 1; /* S'assure que le bouton est au-dessus du menu */
+    margin-top: 10px;
 }
 
 #global #list #filter #menu-button:hover {
@@ -745,6 +746,11 @@ table.dataTable.display    > tbody > tr > td {
     display: flex;
     align-items: center;   /* Aligne verticalement */
     gap: 2em;              /* Espace entre le formulaire et le nombre */
+}
+
+#searchFormContainer h2 {
+    margin: 0px;
+    font-size: 18px;
 }
 
 #floatingForm {

--- a/dev/assets/styles/app.css
+++ b/dev/assets/styles/app.css
@@ -1674,3 +1674,116 @@ ul.plasmyd li.create-plasmid-li {
     padding-left: 0;       /* Supprime l'espace de la puce */
 }
 
+
+
+/* ===========================================================
+   CSS specifique pour le modal d'affichage des fichiers de strain
+=========================================================== */
+.cell-header{
+    display:flex;
+    justify-content:flex-start;
+    margin-bottom:4px;
+}
+
+.open-file-modal{
+    border:none;
+    background:none;
+    cursor:pointer;
+    font-size:14px;
+    color:#666;
+}
+
+.open-file-modal:hover{
+    color:#000;
+}
+
+.custom-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+}
+
+.custom-modal-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.custom-modal-content {
+    position: relative;
+    z-index: 2;
+    width: 90%;
+    max-width: 900px;
+    max-height: 85vh;
+    overflow-y: auto;
+    margin: 40px auto;
+    background: #fff;
+    border-radius: 10px;
+    padding: 20px;
+}
+
+.custom-modal-close {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    border: none;
+    background: none;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+
+.preview-header{
+    margin-bottom:16px;
+    padding-bottom:10px;
+    border-bottom:1px solid #ddd;
+}
+
+.preview-header p{
+    margin:4px 0;
+}
+
+.preview-cards{
+    display:flex;
+    flex-direction:column;
+    gap:12px;
+}
+
+.preview-card{
+    border:1px solid #ddd;
+    border-radius:8px;
+    padding:14px;
+    background:#fafafa;
+}
+
+.preview-card h4{
+    margin:0 0 10px 0;
+    font-size:16px;
+}
+
+.preview-card p{
+    margin:4px 0;
+}
+
+.preview-download-btn{
+    display:inline-block;
+    margin-top:10px;
+    padding:8px 12px;
+    background:#0d6efd;
+    color:#fff;
+    text-decoration:none;
+    border-radius:6px;
+    font-size:14px;
+}
+
+.preview-download-btn:hover{
+    background:#0b5ed7;
+    color:#fff;
+}
+
+.more-files {
+    font-size: 13px;
+    color: #3b82f6; /* bleu doux moderne */
+    font-weight: 500;
+    margin-top: 4px;
+}

--- a/dev/assets/styles/app.css
+++ b/dev/assets/styles/app.css
@@ -517,7 +517,7 @@ button.btn-form:hover,
 }
 
 #global #list #filter  .filter-menu.visible {
-    display: inline-block; /* Affiche le menu lorsque la classe "visible" est ajoutée */
+    display: block !important; /* Affiche le menu lorsque la classe "visible" est ajoutée */
     top : 100%; 
     background: #f1f1f1;
     left: 0;
@@ -562,6 +562,10 @@ button.btn-form:hover,
     background-color: #f9f9f9; /* Couleur de fond */
 }
 
+.filterComponent {
+    padding: 10px !important;
+}
+
 input[type="checkbox"] {
   accent-color: #3c546d;; /* couleur du togunderlinegle */
 }
@@ -571,18 +575,16 @@ input[type="checkbox"] {
 =========================================================== */
 
 #global #list #table {
-    margin-top : 10px; 
-    table-layout: fixed; /* Fixe la largeur des colonnes */
-    overflow-x: auto; 
-    overflow-y: scroll;
-    border-collapse: collapse;
+    margin-top: 10px;
+    overflow-x: auto;
+    overflow-y: visible;
     font-family: 'Arial', sans-serif;
     font-size: 14px;
     color: #333;
-    background-color: #ffffff !important; /* Fond blanc forcé */
+    background-color: #ffffff !important;
     margin-bottom: 20px;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-    height: 100%;
+    height: auto;
 }
 
 .sub-cell {

--- a/dev/src/Controller/SampleController.php
+++ b/dev/src/Controller/SampleController.php
@@ -169,6 +169,15 @@ class SampleController extends AbstractController
             $clone->setUnderLocalisation($sample->getUnderLocalisation());
             $clone->setGps($sample->getGps());
             $clone->setEnvironment($sample->getEnvironment());
+
+            $clone->setBioSample($sample->getBioSample());
+            $clone->setFarmLocation($sample->getFarmLocation());
+            $clone->setHospitalSampleType($sample->getHospitalSampleType());
+            $clone->setHospitalSite($sample->getHospitalSite());
+            $clone->setHospitalWard($sample->getHospitalWard());
+            $clone->setPatientContextType($sample->getPatientContextType());
+            $clone->setSource($sample->getSource());
+
             $clone->setOther($sample->getOther());
             $clone->setDescription($sample->getDescription());
             $clone->setComment($sample->getComment());

--- a/dev/src/Controller/StrainController.php
+++ b/dev/src/Controller/StrainController.php
@@ -900,4 +900,45 @@ class StrainController extends AbstractController
         ]);
     }
 
+    #[Route('/strain/{id}/file-preview/{type}', name: 'strain_file_preview', methods: ['GET'])]
+    public function filePreview(Strain $strain, string $type): Response
+    {
+        $items = [];
+
+        if ($type === 'drugResistance') {
+            $items = $strain->getDrugResistanceOnStrain()->toArray();
+        } elseif ($type === 'phenotype') {
+            $items = $strain->getPhenotype()->toArray();
+        } elseif ($type === 'sequencing') {
+            $items = $strain->getSequencing()->toArray();
+        } else {
+            throw $this->createNotFoundException('Invalid type');
+        }
+
+        usort($items, function ($a, $b) {
+            $dateA = method_exists($a, 'getDate') ? $a->getDate() : null;
+            $dateB = method_exists($b, 'getDate') ? $b->getDate() : null;
+
+            if ($dateA && $dateB) {
+                return $dateB <=> $dateA;
+            }
+
+            if ($dateA && !$dateB) {
+                return -1;
+            }
+
+            if (!$dateA && $dateB) {
+                return 1;
+            }
+
+            return ($b->getId() ?? 0) <=> ($a->getId() ?? 0);
+        });
+
+        return $this->render('strain/_file_preview_cards.html.twig', [
+            'strain' => $strain,
+            'type' => $type,
+            'items' => $items,
+        ]);
+    }
+
 }

--- a/dev/src/Entity/Sample.php
+++ b/dev/src/Entity/Sample.php
@@ -7,6 +7,11 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\Collection;
 
+use App\Enum\HospitalSampleTypeEnum;
+use App\Enum\HospitalSiteEnum;
+use App\Enum\PatientContextTypeEnum;
+use App\Enum\SourceEnum;
+
 #[ORM\Entity(repositoryClass: SampleRepository::class)]
 class Sample
 {
@@ -55,26 +60,26 @@ class Sample
     #[ORM\JoinColumn(nullable: true)]
     private ?User $user = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
+   #[ORM\Column(length: 255, nullable: true)]
     private ?string $bioSample = null;
 
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $farmLocation = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $hospitalSampleType = null;
+    #[ORM\Column(enumType: HospitalSampleTypeEnum::class, nullable: true)]
+    private ?HospitalSampleTypeEnum $hospitalSampleType = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $hospitalSite = null;
+    #[ORM\Column(enumType: HospitalSiteEnum::class, nullable: true)]
+    private ?HospitalSiteEnum $hospitalSite = null;
 
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $hospitalWard = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $patientContextType = null;
+    #[ORM\Column(enumType: PatientContextTypeEnum::class, nullable: true)]
+    private ?PatientContextTypeEnum $patientContextType = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $source = null;
+    #[ORM\Column(enumType: SourceEnum::class, nullable: true)]
+    private ?SourceEnum $source = null;
 
     /**
      * @var Collection<int, Strain>
@@ -279,23 +284,23 @@ class Sample
         return $this;
     }
 
-    public function getHospitalSampleType(): ?string
+    public function getHospitalSampleType(): ?HospitalSampleTypeEnum
     {
         return $this->hospitalSampleType;
     }
 
-    public function setHospitalSampleType(?string $hospitalSampleType): static
+    public function setHospitalSampleType(?HospitalSampleTypeEnum $hospitalSampleType): static
     {
         $this->hospitalSampleType = $hospitalSampleType;
         return $this;
     }
 
-    public function getHospitalSite(): ?string
+    public function getHospitalSite(): ?HospitalSiteEnum
     {
         return $this->hospitalSite;
     }
 
-    public function setHospitalSite(?string $hospitalSite): static
+    public function setHospitalSite(?HospitalSiteEnum $hospitalSite): static
     {
         $this->hospitalSite = $hospitalSite;
         return $this;
@@ -312,23 +317,23 @@ class Sample
         return $this;
     }
 
-    public function getPatientContextType(): ?string
+    public function getPatientContextType(): ?PatientContextTypeEnum
     {
         return $this->patientContextType;
     }
 
-    public function setPatientContextType(?string $patientContextType): static
+    public function setPatientContextType(?PatientContextTypeEnum $patientContextType): static
     {
         $this->patientContextType = $patientContextType;
         return $this;
     }
 
-    public function getSource(): ?string
+    public function getSource(): ?SourceEnum
     {
         return $this->source;
     }
 
-    public function setSource(?string $source): static
+    public function setSource(?SourceEnum $source): static
     {
         $this->source = $source;
         return $this;

--- a/dev/src/Enum/HospitalSampleTypeEnum.php
+++ b/dev/src/Enum/HospitalSampleTypeEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enum;
+
+enum HospitalSampleTypeEnum: string
+{
+    case WARD_ENVIRONMENT = 'ward_environment';
+    case PATIENT = 'patient';
+}

--- a/dev/src/Enum/HospitalSiteEnum.php
+++ b/dev/src/Enum/HospitalSiteEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enum;
+
+enum HospitalSiteEnum: string
+{
+    case CENTRE = 'centre';
+    case EST = 'est';
+    case NORD = 'nord';
+    case SUD = 'sud';
+}

--- a/dev/src/Enum/PatientContextTypeEnum.php
+++ b/dev/src/Enum/PatientContextTypeEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enum;
+
+enum PatientContextTypeEnum: string
+{
+    case SCREENING = 'screening';
+    case INFECTION = 'infection';
+}

--- a/dev/src/Enum/SourceEnum.php
+++ b/dev/src/Enum/SourceEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enum;
+
+enum SourceEnum: string
+{
+    case FARM = 'farm';
+    case RHONE_RIVERBANK = 'Rhone_riverbank';
+    case HOSPITAL = 'hospital';
+    case SIAMU = 'SIAMU';
+}

--- a/dev/src/Form/SampleFormType.php
+++ b/dev/src/Form/SampleFormType.php
@@ -2,8 +2,13 @@
 
 namespace App\Form;
 
+use App\Enum\HospitalSampleTypeEnum;
+use App\Enum\HospitalSiteEnum;
+use App\Enum\PatientContextTypeEnum;
+use App\Enum\SourceEnum;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class SampleFormType extends AbstractType
@@ -37,6 +42,38 @@ class SampleFormType extends AbstractType
             ])
             ->add('environment', options:[
                 'label' => 'Environnement'
+            ])
+            ->add('bioSample', options:[
+                'label' => 'Bio Sample',
+                'required' => false
+            ])
+            ->add('farmLocation', options:[
+                'label' => 'Farm Location',
+                'required' => false
+            ])
+            ->add('hospitalSampleType', EnumType::class, options:[
+                'class' => HospitalSampleTypeEnum::class,
+                'label' => 'Hospital Sample Type',
+                'required' => false
+            ])
+            ->add('hospitalSite', EnumType::class, options:[
+                'class' => HospitalSiteEnum::class,
+                'label' => 'Hospital Site',
+                'required' => false
+            ])
+            ->add('hospitalWard', options:[
+                'label' => 'Hospital Ward',
+                'required' => false
+            ])
+            ->add('patientContextType', EnumType::class, options:[
+                'class' => PatientContextTypeEnum::class,
+                'label' => 'Patient Context Type',
+                'required' => false
+            ])
+            ->add('source', EnumType::class, options:[
+                'class' => SourceEnum::class,
+                'label' => 'Source',
+                'required' => false
             ])
             ->add('other', options:[
                 'label' => 'Other Sources'

--- a/dev/templates/bin/main.html.twig
+++ b/dev/templates/bin/main.html.twig
@@ -19,6 +19,8 @@
                 <div id="table">
                     {% include "strain/list.html.twig" %}
                 </div>
+                <div id="table-controls-footer"></div>
+
             </div>
         <br></br>        
         </div>  

--- a/dev/templates/collec/main.html.twig
+++ b/dev/templates/collec/main.html.twig
@@ -8,15 +8,17 @@
             </div>
         {% endif %}
         <div id="list">
-            <div id="filter">
+            <div id="filter" class="filterComponent">
                 {% include 'collec/_filter_form_datatable_collect.html.twig' %}
             </div>
             <div id="message">
                 {% include './message.html.twig' %}
             </div>
+             <div id="table-header-toolbar"></div>
             <div id="table">
                 {% include "collec/list.html.twig" %}
             </div>
+            <div id="table-controls-footer"></div>
         </div>
         <br></br>
     </div> 

--- a/dev/templates/drug/main.html.twig
+++ b/dev/templates/drug/main.html.twig
@@ -8,15 +8,17 @@
             </div>
         {% endif %}
         <div id="list">
-            <div id="filter">
+            <div id="filter" class="filterComponent">
                 {% include 'drug/_filter_form_datatable_drug.html.twig' %}
             </div>
             <div id="message">
                 {% include './message.html.twig' %}
             </div>
+            <div id="table-header-toolbar"></div>
             <div id="table">
                 {% include "drug/list.html.twig" %}
             </div>
+            <div id="table-controls-footer"></div>
         </div>
         <br></br>
     </div>  

--- a/dev/templates/methodSequencingType/main.html.twig
+++ b/dev/templates/methodSequencingType/main.html.twig
@@ -10,7 +10,7 @@
     {% endif %}
 
     <div id="list">
-      <div id="filter">
+      <div id="filter" class="filterComponent">
         {% include 'methodSequencingType/_filter_form_datatable_methodsequencingtype.html.twig' %}
       </div>
 
@@ -18,9 +18,14 @@
         {% include './message.html.twig' %}
       </div>
 
+      <div id="table-header-toolbar"></div>
+
       <div id="table">
         {% include 'methodSequencingType/list.html.twig' %}
       </div>
+
+      <div id="table-controls-footer"></div>
+
     </div>
 
     <br />

--- a/dev/templates/phenotypeType/main.html.twig
+++ b/dev/templates/phenotypeType/main.html.twig
@@ -10,7 +10,7 @@
     {% endif %}
 
     <div id="list">
-      <div id="filter">
+      <div id="filter" class="filterComponent">
         {% include 'phenotypeType/_filter_form_datatable_phenotypetype.html.twig' %}
       </div>
 
@@ -18,11 +18,15 @@
         {% include './message.html.twig' %}
       </div>
 
+      <div id="table-header-toolbar"></div>
+
       <div id="table">
         {% include 'phenotypeType/list.html.twig' %}
       </div>
-    </div>
 
+      <div id="table-controls-footer"></div>
+      
+    </div>
     <br />
   </div>
 {% endblock %}

--- a/dev/templates/plasmyd/main.html.twig
+++ b/dev/templates/plasmyd/main.html.twig
@@ -9,15 +9,17 @@
             </div>
         {% endif %}
         <div id="list">
-            <div id="filter">
+            <div id="filter" class="filterComponent">
                 {% include 'plasmyd/_filter_form_datatable_plasmyd.html.twig' %}
             </div>
             <div id="message">
                 {% include './message.html.twig' %}
             </div>
+            <div id="table-header-toolbar"></div>
             <div id="table">
                 {% include "plasmyd/list.html.twig" %}
             </div>
+            <div id="table-controls-footer"></div>
         </div>
         <br></br>
     </div>  

--- a/dev/templates/project/main.html.twig
+++ b/dev/templates/project/main.html.twig
@@ -7,15 +7,17 @@
                 </div>
             {% endif %}
             <div id="list">
-                <div id="filter">
+                <div id="filter" class="filterComponent">
                     {% include 'project/_filter_form_datatable_project.html.twig' %}
                 </div>
                 <div id="message">
                     {% include './message.html.twig' %}
                 </div>
+                <div id="table-header-toolbar"></div>
                 <div id="table">
                     {% include "project/list.html.twig" %}
                 </div>
+                <div id="table-controls-footer"></div>
             </div>
         <br></br>        
         </div>  

--- a/dev/templates/publication/main.html.twig
+++ b/dev/templates/publication/main.html.twig
@@ -7,15 +7,17 @@
                 </div>
             {% endif %}
             <div id="list">
-                <div id="filter">
+                <div id="filter" class="filterComponent">
                     {% include 'publication/_filter_form_datatable_publication.html.twig' %}
                 </div>
                 <div id="message">
                     {% include './message.html.twig' %}
                 </div>
+                <div id="table-header-toolbar"></div>
                 <div id="table">
                     {% include "publication/list.html.twig" %}
                 </div>
+                <div id="table-controls-footer"></div>
             </div>
         <br></br>        
         </div>  

--- a/dev/templates/sample/_form.html.twig
+++ b/dev/templates/sample/_form.html.twig
@@ -10,6 +10,16 @@
     {{ form_row(sampleForm.gps) }}
     {{ form_row(sampleForm.environment) }}
     {{ form_row(sampleForm.other) }}
+
+    {# nouveaux champs #}
+    {{ form_row(sampleForm.bioSample) }}
+    {{ form_row(sampleForm.farmLocation) }}
+    {{ form_row(sampleForm.hospitalSampleType) }}
+    {{ form_row(sampleForm.hospitalSite) }}
+    {{ form_row(sampleForm.hospitalWard) }}
+    {{ form_row(sampleForm.patientContextType) }}
+    {{ form_row(sampleForm.source) }}
+
     {{ form_row(sampleForm.description) }}
     {{ form_row(sampleForm.comment) }}
 

--- a/dev/templates/sample/list.html.twig
+++ b/dev/templates/sample/list.html.twig
@@ -37,6 +37,13 @@
                     <th>Under Localisation</th>
                     <th>GPS</th>
                     <th>Environnement</th>
+                    <th>Bio Sample</th>
+                    <th>Farm Location</th>
+                    <th>Hospital Sample Type</th>
+                    <th>Hospital Site</th>
+                    <th>Hospital Ward</th>
+                    <th>Patient Context Type</th>
+                    <th>Source</th>
                     <th>Other</th>
                     <th>Description</th>
                     <th>Comment</th>
@@ -62,6 +69,13 @@
                         <td>{{ sample.underLocalisation }}</td>
                         <td>{{ sample.gps }}</td>
                         <td>{{ sample.environment }}</td>
+                        <td>{{ sample.bioSample }}</td>
+                        <td>{{ sample.farmLocation }}</td>
+                        <td>{{ sample.hospitalSampleType ? sample.hospitalSampleType.value : '' }}</td>
+                        <td>{{ sample.hospitalSite ? sample.hospitalSite.value : '' }}</td>
+                        <td>{{ sample.hospitalWard }}</td>
+                        <td>{{ sample.patientContextType ? sample.patientContextType.value : '' }}</td>
+                        <td>{{ sample.source ? sample.source.value : '' }}</td>
                         <td>{{ sample.other }}</td>
                         <td>{{ sample.description }}</td>
                         <td>{{ sample.comment }}</td>

--- a/dev/templates/sample/main.html.twig
+++ b/dev/templates/sample/main.html.twig
@@ -12,7 +12,7 @@
         {% endif %}
 
         <div id="list">
-            <div id="filter">
+            <div id="filter" class="filterComponent">
                 {% include 'sample/_filter_form_datatable_sample.html.twig' %}
             </div>
 
@@ -20,9 +20,14 @@
                 {% include './message.html.twig' %}
             </div>
 
+            <div id="table-header-toolbar"></div>
+
             <div id="table">
                 {% include "sample/list.html.twig" %}
             </div>
+
+            <div id="table-controls-footer"></div>
+
         </div>
 
         <br>

--- a/dev/templates/sample/main.html.twig
+++ b/dev/templates/sample/main.html.twig
@@ -28,27 +28,4 @@
         <br>
     </div>
 
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const toggleBtn = document.getElementById('toggleForm');
-            const formDiv = document.getElementById('form');
-            const closeBtn = document.getElementById('closeForm');
-
-            if (!toggleBtn || !formDiv || !closeBtn) return;
-
-            // Ouvrir le formulaire avec le bouton +
-            toggleBtn.addEventListener('click', () => {
-                formDiv.classList.remove('hidden');
-                formDiv.classList.add('show');
-                toggleBtn.style.display = 'none';
-            });
-
-            // Fermer le formulaire avec le bouton -
-            closeBtn.addEventListener('click', () => {
-                formDiv.classList.remove('show');
-                formDiv.classList.add('hidden');
-                toggleBtn.style.display = 'inline-block';
-            });
-        });
-    </script>
 {% endblock %}

--- a/dev/templates/sample/main.html.twig
+++ b/dev/templates/sample/main.html.twig
@@ -3,21 +3,52 @@
 {% block body %}
     <div id="global">
         {% if 'ROLE_SEARCH' in app.user.roles or 'ROLE_ADMIN' in app.user.roles %}
-            <div id="form">
+            <button id="toggleForm">+</button>
+
+            <div id="form" class="hidden">
+                <button id="closeForm">-</button>
                 {% include "sample/create.html.twig" %}
             </div>
         {% endif %}
+
         <div id="list">
             <div id="filter">
                 {% include 'sample/_filter_form_datatable_sample.html.twig' %}
             </div>
+
             <div id="message">
                 {% include './message.html.twig' %}
             </div>
+
             <div id="table">
                 {% include "sample/list.html.twig" %}
             </div>
         </div>
-        <br></br>
-    </div>  
+
+        <br>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const toggleBtn = document.getElementById('toggleForm');
+            const formDiv = document.getElementById('form');
+            const closeBtn = document.getElementById('closeForm');
+
+            if (!toggleBtn || !formDiv || !closeBtn) return;
+
+            // Ouvrir le formulaire avec le bouton +
+            toggleBtn.addEventListener('click', () => {
+                formDiv.classList.remove('hidden');
+                formDiv.classList.add('show');
+                toggleBtn.style.display = 'none';
+            });
+
+            // Fermer le formulaire avec le bouton -
+            closeBtn.addEventListener('click', () => {
+                formDiv.classList.remove('show');
+                formDiv.classList.add('hidden');
+                toggleBtn.style.display = 'inline-block';
+            });
+        });
+    </script>
 {% endblock %}

--- a/dev/templates/strain/_file_preview_cards.html.twig
+++ b/dev/templates/strain/_file_preview_cards.html.twig
@@ -1,0 +1,67 @@
+<div class="preview-header">
+    <p><strong>Strain ID :</strong> {{ strain.id }}</p>
+    <p><strong>Type :</strong> {{ type }}</p>
+    <p><strong>Nombre d'éléments :</strong> {{ items|length }}</p>
+</div>
+
+{% if items is empty %}
+    <div class="preview-card">
+        <p>Aucun élément trouvé.</p>
+    </div>
+{% else %}
+    <div class="preview-cards">
+        {% for item in items %}
+            <div class="preview-card">
+
+                {% if type == 'drugResistance' %}
+                    <h4>{{ item.drugResistance ? item.drugResistance.name : '--' }}</h4>
+
+                    <p><strong>Date :</strong> {{ item.date ? item.date|date('d/m/Y') : '--' }}</p>
+                    <p><strong>Concentration :</strong> {{ item.concentration ?: '--' }}</p>
+                    <p><strong>Concentration unit :</strong> {{ item.concentrationUnit ?: '--' }}</p>
+                    <p><strong>Resistant :</strong> {{ item.resistant ? 'yes' : 'no' }}</p>
+                    <p><strong>Comment :</strong> {{ item.comment ?: '--' }}</p>
+                    <p><strong>Description :</strong> {{ item.description ?: '--' }}</p>
+                    <p><strong>File :</strong> {{ item.nameFile ?: '--' }}</p>
+
+                    {% if item.nameFile %}
+                        <a href="/documents/download/drugs/{{ item.nameFile }}" class="preview-download-btn">
+                            Download
+                        </a>
+                    {% endif %}
+
+                {% elseif type == 'phenotype' %}
+                    <h4>{{ item.phenotypeType ? item.phenotypeType.type : '--' }}</h4>
+
+                    <p><strong>Date :</strong> {{ item.date ? item.date|date('d/m/Y') : '--' }}</p>
+                    <p><strong>Technique :</strong> {{ item.technique ?: '--' }}</p>
+                    <p><strong>Mesure :</strong> {{ item.mesure ?: '--' }}</p>
+                    <p><strong>File :</strong> {{ item.fileName ?: '--' }}</p>
+
+                    {% if item.fileName %}
+                        <a href="/documents/download/phenotype/{{ item.fileName }}" class="preview-download-btn">
+                            Download
+                        </a>
+                    {% endif %}
+
+                {% elseif type == 'sequencing' %}
+                    <h4>{{ item.name ?: '--' }}</h4>
+
+                    <p><strong>Date :</strong> {{ item.date ? item.date|date('d/m/Y') : '--' }}</p>
+                    <p><strong>Method :</strong> {{ item.name ?: '--' }}</p>
+                    <p><strong>File :</strong> {{ item.nameFile ?: '--' }}</p>
+
+                    {% if item.nameFile %}
+                        <a href="/documents/download/sequencing/{{ item.nameFile }}" class="preview-download-btn">
+                            Download
+                        </a>
+                    {% endif %}
+
+                {% else %}
+                    <p>Type inconnu</p>
+                {% endif %}
+
+            </div>
+        {% endfor %}
+    </div>
+{% endif %}

--- a/dev/templates/strain/list.html.twig
+++ b/dev/templates/strain/list.html.twig
@@ -302,240 +302,186 @@
                             </td>
 
                             <td>
-                                <div class="sub-cell drugResistanceOnStrain clicable" 
-                                    data-info='
-                                        name: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.drugResistance.name  : '--'}}
-                                        concentration: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.concentration : '--'}}
-                                        concentration_unit: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.concentrationUnit : '--' }}
-                                        date: {{ strain.drugResistanceOnStrain|first and strain.drugResistanceOnStrain|first.date ? strain.drugResistanceOnStrain|first.date|date("Y-m-d") : "--" }}
-                                        resistant: {{ strain.drugResistanceOnStrain|first ? (strain.drugResistanceOnStrain|first.resistant ? 'yes' : 'no') : '--' }}
-                                        comment: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.comment   : '--'}}
-                                        description: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.description  : '--'}}
-                                        file: {{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.nameFile : '--'}}'                       
-                                    data-file='{{ strain.drugResistanceOnStrain|first ? strain.drugResistanceOnStrain|first.nameFile : '--'}}'
-                                >
-                                    {% if strain.drugResistanceOnStrain is not empty %}
-                                        {{ '● ' ~ strain.drugResistanceOnStrain[0].drugResistance.name }}
-                                        {% if strain.drugResistanceOnStrain[0].date is defined and strain.drugResistanceOnStrain[0].date %}
-                                            [{{ strain.drugResistanceOnStrain[0].date|date("d/m/Y") }}]
-                                        {% endif %}
-                                        <br>
-                                        {{strain.drugResistanceOnStrain[0].concentration}}
-                                        {% if strain.drugResistanceOnStrain[0].concentrationUnit %}
-                                            {{ strain.drugResistanceOnStrain[0].concentrationUnit }}
-                                        {% endif %}
-                                        {% if strain.drugResistanceOnStrain[0].resistant == 1 %}
-                                            <a class="resistant-display-red"> resistante : &#9888; </a>
-                                        {% else %}
-                                            <a class="resistant-display-green"> sensible : &#x2713; </a>
-                                        {% endif %}<br>
+                                {% if strain.drugResistanceOnStrain is not empty %}
+                                    <div class="cell-header">
+                                        <button class="open-file-modal"
+                                                data-strain-id="{{ strain.id }}"
+                                                data-type="drugResistance"
+                                                title="See all drug resistance files">
+                                            <i class="fa-solid fa-eye"></i>
+                                        </button>
+                                    </div>
 
-                                        {% if strain.drugResistanceOnStrain[0].nameFile is defined and strain.drugResistanceOnStrain[0].nameFile %}
-                                            {% set nameFile = strain.drugResistanceOnStrain[0].nameFile %}
-                                            {% set maxLength = 20 %}
-                                            {% if nameFile|length > maxLength %}
-                                                {{ nameFile|slice(0,12) ~ '...' ~ nameFile|slice(-8) }}
-                                            {% else %}
-                                                {{ nameFile }}
-                                            {% endif %}
-                                        {% endif %}
-                                    {% else %}
-                                        --
-                                    {% endif %}
-                                </div>  
+                                    <div class="cell-content">
+                                         {% set maxLength = strain.drugResistanceOnStrain|length %}
+                                            {% for i in 0..(maxLength - 1) %}
+                                            {% set item = strain.drugResistanceOnStrain[i] %}
 
-                                {% if (strain.drugResistanceOnStrain is not empty)%}
-                                    {% set maxLength = strain.drugResistanceOnStrain|length %}
-                                    {% if maxLength > 1 %} 
-                                        {% for i in 1..(maxLength - 1) %}
-                                            <div id="sub-cell-drugResistanceOnStrain_{{i}}"
+                                            <div id="sub-cell-drugResistanceOnStrain_{{ i }}"
                                                 class="sub-cell drugResistanceOnStrain clicable"
                                                 data-info='
-                                                    name: {{ strain.drugResistanceOnStrain[i] is defined and strain.drugResistanceOnStrain[i] ? strain.drugResistanceOnStrain[i].drugResistance.name  : '--'}}
-                                                    concentration: {{ strain.drugResistanceOnStrain[i] is defined and strain.drugResistanceOnStrain[i] ? strain.drugResistanceOnStrain[i].concentration : '--'}}
-                                                    resistant: {{ strain.drugResistanceOnStrain[i] is defined and strain.drugResistanceOnStrain[i] ? (strain.drugResistanceOnStrain[i].resistant  ? 'yes' : 'no') : '--' }}
-                                                    comment: {{ strain.drugResistanceOnStrain[i] is defined and strain.drugResistanceOnStrain[i] ? strain.drugResistanceOnStrain[i].comment  : '--'}}
-                                                    description: {{ strain.drugResistanceOnStrain[i] is defined and strain.drugResistanceOnStrain[i] ? strain.drugResistanceOnStrain[i].description  : '--'}}
-                                                    file: {{ strain.drugResistanceOnStrain[i] is defined and strain.drugResistanceOnStrain[i].nameFile is defined ? strain.drugResistanceOnStrain[i].nameFile : '--' }}'
-                                                data-file='{{ (strain.drugResistanceOnStrain|length > i and strain.drugResistanceOnStrain[i].nameFile) ? strain.drugResistanceOnStrain[i].nameFile : "--" }}'
-                                            > 
-                                                {{ strain.drugResistanceOnStrain[i] is defined ? '● ' ~ strain.drugResistanceOnStrain[i].drugResistance.name : '' }}
-                                                {% if strain.drugResistanceOnStrain[i].date is defined and strain.drugResistanceOnStrain[i].date %}
-                                                    [{{ strain.drugResistanceOnStrain[i].date|date("d/m/Y") }}]
+                                                    name: {{ item.drugResistance.name is defined ? item.drugResistance.name : "--" }}
+                                                    concentration: {{ item.concentration is defined and item.concentration ? item.concentration : "--" }}
+                                                    concentration_unit: {{ item.concentrationUnit is defined and item.concentrationUnit ? item.concentrationUnit : "--" }}
+                                                    date: {{ item.date is defined and item.date ? item.date|date("Y-m-d") : "--" }}
+                                                    resistant: {{ item.resistant is defined ? (item.resistant ? "yes" : "no") : "--" }}
+                                                    comment: {{ item.comment is defined and item.comment ? item.comment : "--" }}
+                                                    description: {{ item.description is defined and item.description ? item.description : "--" }}
+                                                    file: {{ item.nameFile is defined and item.nameFile ? item.nameFile : "--" }}'
+                                                data-file='{{ item.nameFile is defined and item.nameFile ? item.nameFile : "--" }}'>
+
+                                                {{ '● ' ~ item.drugResistance.name }}
+                                                {% if item.date is defined and item.date %}
+                                                    [{{ item.date|date("d/m/Y") }}]
                                                 {% endif %}
                                                 <br>
-                                                {{ strain.drugResistanceOnStrain[i] is defined ? strain.drugResistanceOnStrain[i].concentration : '' }}
-                                                        {% if strain.drugResistanceOnStrain[i].concentrationUnit %}
-                                                    {{ strain.drugResistanceOnStrain[i].concentrationUnit }}
-                                                {% endif %}
-                                                {% if strain.drugResistanceOnStrain[i] is defined %}
-                                                    {% if strain.drugResistanceOnStrain[i].resistant == 1 %}
-                                                        <a class="resistant-display-red"> resistante : &#9888; </a>
-                                                    {% else %}
-                                                        <a class="resistant-display-green"> sensible : &#x2713; </a>
-                                                    {% endif %}<br>
 
-                                                    {# FICHIER (affiché seulement si il existe) #}
-                                                    {% if strain.drugResistanceOnStrain[i].nameFile is defined and strain.drugResistanceOnStrain[i].nameFile %}
-                                                        {% set nameFile = strain.drugResistanceOnStrain[i].nameFile %}
-                                                        {% set maxLength = 20 %}
-                                                        {% if nameFile|length > maxLength %}
-                                                            {{ nameFile|slice(0,12) ~ '...' ~ nameFile|slice(-8) }}
-                                                        {% else %}
-                                                            {{ nameFile }}
-                                                        {% endif %}
-                                                    {% endif %}                                        
-                                                
+                                                {{ item.concentration }}
+                                                {% if item.concentrationUnit %}
+                                                    {{ item.concentrationUnit }}
+                                                {% endif %}
+
+                                                {% if item.resistant == 1 %}
+                                                    <a class="resistant-display-red"> resistante : &#9888; </a>
                                                 {% else %}
-                                                    --
+                                                    <a class="resistant-display-green"> sensible : &#x2713; </a>
+                                                {% endif %}
+                                                <br>
+
+                                                {% if item.nameFile is defined and item.nameFile %}
+                                                    {% set nameFile = item.nameFile %}
+                                                    {% set displayMaxLength = 20 %}
+
+                                                    {% if nameFile|length > displayMaxLength %}
+                                                        {{ nameFile|slice(0, 12) ~ '...' ~ nameFile|slice(-8) }}
+                                                    {% else %}
+                                                        {{ nameFile }}
+                                                    {% endif %}
                                                 {% endif %}
                                             </div>
                                         {% endfor %}
-                                    {% endif %}
+                                    </div>
+                                {% else %}
+                                    --
                                 {% endif %}
                             </td>
 
                             <td>
-                                <div class="sub-cell phenotype clicable" 
-                                    data-info='
-                                            phenotype: {{ strain.phenotype|first ? strain.phenotype|first.phenotypeType.type : '--'}}
-                                            technique: {{ strain.phenotype|first ? strain.phenotype|first.technique : "--" }}
-                                            mesure: {{ strain.phenotype|first ? strain.phenotype|first.mesure : "--" }}
-                                            date: {{ strain.phenotype|first ? strain.phenotype|first.date|date('d/m/Y') : "--" }}
-                                            file: {{ strain.phenotype|first ? strain.phenotype|first.fileName : "--" }}'
-                                            data-file='{{ strain.phenotype|first ? strain.phenotype|first.fileName : '--'}}'
-                                >
-                                    {% if strain.phenotype is not empty %}
-                                        {{ '● ' ~ strain.phenotype[0].phenotypeType.type }}
-                                        {% if strain.phenotype[0].date is defined and strain.phenotype[0].date %}
-                                            [{{ strain.phenotype[0].date|date("d/m/Y") }}]
-                                        {% endif %}
-                                        <br>
-                                        {{strain.phenotype[0].mesure}}
-                                        <br>
+                                {% if strain.phenotype is not empty %}
+                                    <div class="cell-header">
+                                        <button class="open-file-modal"
+                                                data-strain-id="{{ strain.id }}"
+                                                data-type="phenotype"
+                                                title="See all phenotype files">
+                                            <i class="fa-solid fa-eye"></i>
+                                        </button>
+                                    </div>
 
-                                        {% if strain.phenotype[0].fileName is defined and strain.phenotype[0].fileName %}
-                                            {% set nameFile = strain.phenotype[0].fileName %}
-                                            {% set maxLength = 20 %}
-                                            {% if nameFile|length > maxLength %}
-                                                {{ nameFile|slice(0,12) ~ '...' ~ nameFile|slice(-8) }}
-                                            {% else %}
-                                                {{ nameFile }}
-                                            {% endif %}
-                                        {% endif %}
-                                    
-                                    {% else %}
-                                        --
-                                    {% endif %}
-                                </div>
+                                    <div class="cell-content">
+                                        {% set maxLength = strain.phenotype|length %}
+                                        {% set start = maxLength > 3 ? maxLength - 3 : 0 %}
 
-                                {% if (strain.phenotype is not empty)%}
-                                    {% set maxLength = strain.phenotype|length %}
-                                    {% if maxLength > 1 %} 
-                                        {% for i in 1..(maxLength - 1) %}
-                                            <div id="sub-cell-phenotype_{{i}}"
+                                        {% for i in start..(maxLength - 1) %}
+                                            {% set item = strain.phenotype[i] %}
+
+                                            <div id="sub-cell-phenotype_{{ i }}"
                                                 class="sub-cell phenotype clicable"
                                                 data-info='
-                                            phenotype: {{ (strain.phenotype|length > i) ? strain.phenotype[i].phenotypeType.type : "--" }}
-                                            technique: {{ (strain.phenotype|length > i) ? strain.phenotype[i].technique : "--" }}
-                                            mesure: {{ (strain.phenotype|length > i) ? strain.phenotype[i].mesure : "--" }}
-                                            date: {{ (strain.phenotype|length > i) ? strain.phenotype[i].date|date('d/m/Y') : "--" }}
-                                            file: {{ (strain.phenotype|length > i and strain.phenotype[i].fileName) ? strain.phenotype[i].fileName : "--" }}'
-                                            data-file='{{ (strain.phenotype|length > i and strain.phenotype[i].fileName) ? strain.phenotype[i].fileName : "--" }}'
-                                            >
-                                                {% if strain.phenotype|length > i %}
-                                                    {{ '● ' ~ strain.phenotype[i].phenotypeType.type }}
-                                                    {% if strain.phenotype[i].date is defined and strain.phenotype[i].date %}
-                                                        [{{ strain.phenotype[i].date|date("d/m/Y") }}]
-                                                    {% endif %}
-                                                    <br>
-                                                    {{strain.phenotype[i].mesure}}  
-                                                    <br>
-                                                    {% if strain.phenotype[i].fileName is defined and strain.phenotype[i].fileName %}
-                                                        {% set nameFile = strain.phenotype[i].fileName %}
-                                                        {% set maxLength = 20 %}
-                                                        {% if nameFile|length > maxLength %}
-                                                            {{ nameFile|slice(0,12) ~ '...' ~ nameFile|slice(-8) }}
-                                                        {% else %}
-                                                            {{ nameFile }}
-                                                        {% endif %}
-                                                    {% endif %}
+                                                    phenotype: {{ item.phenotypeType.type is defined ? item.phenotypeType.type : "--" }}
+                                                    technique: {{ item.technique is defined and item.technique ? item.technique : "--" }}
+                                                    mesure: {{ item.mesure is defined and item.mesure ? item.mesure : "--" }}
+                                                    date: {{ item.date is defined and item.date ? item.date|date("d/m/Y") : "--" }}
+                                                    file: {{ item.fileName is defined and item.fileName ? item.fileName : "--" }}'
+                                                data-file='{{ item.fileName is defined and item.fileName ? item.fileName : "--" }}'>
 
-                                                {% else %}
-                                                    --
+                                                {{ '● ' ~ item.phenotypeType.type }}
+                                                {% if item.date is defined and item.date %}
+                                                    [{{ item.date|date("d/m/Y") }}]
+                                                {% endif %}
+                                                <br>
+
+                                                {{ item.mesure }}
+                                                <br>
+
+                                                {% if item.fileName is defined and item.fileName %}
+                                                    {% set nameFile = item.fileName %}
+                                                    {% set displayMaxLength = 20 %}
+
+                                                    {% if nameFile|length > displayMaxLength %}
+                                                        {{ nameFile|slice(0, 12) ~ '...' ~ nameFile|slice(-8) }}
+                                                    {% else %}
+                                                        {{ nameFile }}
+                                                    {% endif %}
                                                 {% endif %}
                                             </div>
                                         {% endfor %}
-                                    {% endif %}
+                                        {% if maxLength > 3 %}
+                                            <div class="sub-cell more-files">
+                                                +{{ maxLength - 3 }} more files
+                                            </div>
+                                        {% endif %}
+                                    </div>
+
+                                {% else %}
+                                    --
                                 {% endif %}
                             </td>
-                            
+
                             <td>
-                                <div class="sequencing clicable" 
-                                    data-info='
-                                            date : {{ strain.sequencing|first ? strain.sequencing|first.date|date('d/m/Y')  : '--'}}
-                                            method : {{ strain.sequencing|first ? strain.sequencing|first.name  : '--'}}
-                                            file : {{ strain.sequencing|first ? strain.sequencing|first.nameFile  : '--'}}'
-                                    data-file='{{ strain.sequencing|first ? strain.sequencing|first.nameFile : '--'}}'
-                                >
-                                    {% if strain.sequencing is not empty %}
-                                        {{ '● ' ~ strain.sequencing[0].name }}
-                                        {% if strain.sequencing[0].date is defined and strain.sequencing[0].date %}
-                                            [{{ strain.sequencing[0].date|date("d/m/Y") }}]
-                                        {% endif %}
-                                        <br>
-                                        {% set nameFile = strain.sequencing[0].nameFile ?: strain.sequencing[0].nameFile %}
-                                        {% set maxLength = 15 %}
+                                {% if strain.sequencing is not empty %}
+                                    <div class="cell-header">
+                                        <button class="open-file-modal"
+                                                data-strain-id="{{ strain.id }}"
+                                                data-type="sequencing"
+                                                title="See all sequencing files">
+                                            <i class="fa-solid fa-eye"></i>
+                                        </button>
+                                    </div>
 
-                                        {% if nameFile|length > maxLength %}
-                                            {% set prefix = nameFile|slice(0, 12) %}
-                                            {% set suffix = nameFile|slice(-10) %}
-                                            {{ prefix ~ '...' ~ suffix }}
-                                        {% else %}
-                                            {{ nameFile }}
-                                        {% endif %} <br>
-                                    {% else %}
-                                        --
-                                    {% endif %}
-                                </div>
+                                    <div class="cell-content">
+                                        {% set maxLength = strain.sequencing|length %}
+                                        {% set start = maxLength > 3 ? maxLength - 3 : 0 %}
 
-                                 {% if strain.sequencing is not empty %}
-                                    {% set seqLength = strain.sequencing|length %}
-                                    {% if seqLength > 1 %}
-                                        {% for i in 1..(seqLength - 1) %}
-                                            {% set seqItem = strain.sequencing[i] %}
+                                        {% for i in start..(maxLength - 1) %}
+                                            {% set item = strain.sequencing[i] %}
+
                                             <div id="sub-cell-sequencing_{{ i }}"
                                                 class="sub-cell sequencing clicable"
                                                 data-info='
-                                                    date : {{ seqItem.date is defined and seqItem.date ? seqItem.date|date('d/m/Y') : '--' }}
-                                                    method : {{ seqItem.name is defined and seqItem.name ? seqItem.name : '--' }}
-                                                    file : {{ seqItem.nameFile is defined and seqItem.nameFile ? seqItem.nameFile : '--' }}'
-                                                data-file='{{ seqItem.nameFile is defined ? seqItem.nameFile : "--" }}'>
-                                                
-                                                 {{ seqItem.name is defined ? '● ' ~ seqItem.name : '' }}
-                                                    {% if seqItem.date is defined and seqItem.date %}
-                                                        [{{ seqItem.date|date("d/m/Y") }}]
-                                                    {% endif %}
-                                                    <br>
-                                                
-                                                {% if seqItem.nameFile is defined %}
-                                                    {% set fileName = seqItem.nameFile %}
-                                                    {% set displayMax = 10 %}
-                                                    {% if fileName|length > displayMax %}
-                                                        {% set prefix = fileName|slice(0, 12) %}
-                                                        {% set suffix = fileName|slice(-10) %}
-                                                        {{ prefix ~ '...' ~ suffix }}
+                                                    date: {{ item.date is defined and item.date ? item.date|date("d/m/Y") : "--" }}
+                                                    method: {{ item.name is defined and item.name ? item.name : "--" }}
+                                                    file: {{ item.nameFile is defined and item.nameFile ? item.nameFile : "--" }}'
+                                                data-file='{{ item.nameFile is defined and item.nameFile ? item.nameFile : "--" }}'>
+
+                                                {{ item.name is defined and item.name ? '● ' ~ item.name : '' }}
+                                                {% if item.date is defined and item.date %}
+                                                    [{{ item.date|date("d/m/Y") }}]
+                                                {% endif %}
+                                                <br>
+
+                                                {% if item.nameFile is defined and item.nameFile %}
+                                                    {% set fileName = item.nameFile %}
+                                                    {% set displayMaxLength = 15 %}
+
+                                                    {% if fileName|length > displayMaxLength %}
+                                                        {{ fileName|slice(0, 12) ~ '...' ~ fileName|slice(-10) }}
                                                     {% else %}
                                                         {{ fileName }}
                                                     {% endif %}
-                                                    <br>
                                                 {% else %}
                                                     --
                                                 {% endif %}
                                             </div>
                                         {% endfor %}
-                                    {% endif %}
-                                {% endif %}                        
+                                         {% if maxLength > 3 %}
+                                            <div class="sub-cell more-files">
+                                                +{{ maxLength - 3 }} more files
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                {% else %}
+                                    --
+                                {% endif %}
                             </td>
 
                             <td>
@@ -704,6 +650,18 @@
     <a id="popupDownload" href="#" style="display: none; padding: 5px 10px; background: blue; color: white; text-decoration: none; border-radius: 5px;">
         Download
     </a>
+</div>
+
+<div id="filePreviewModal" class="custom-modal" style="display:none;">
+    <div class="custom-modal-overlay"></div>
+
+    <div class="custom-modal-content">
+        <button type="button" id="file-preview-close" class="custom-modal-close">&times;</button>
+        <h3 id="file-preview-title">Files preview</h3>
+        <div id="file-preview-body">
+            <p>Loading...</p>
+        </div>
+    </div>
 </div>
 
 {% if app.session.flashbag.has('warning') %}

--- a/dev/templates/strain/list.html.twig
+++ b/dev/templates/strain/list.html.twig
@@ -121,6 +121,15 @@
                                         localisation : {{ strain.prelevement ? strain.prelevement.localisation : "--" }}
                                         under-localisation : {{ strain.prelevement ? strain.prelevement.underLocalisation : "--" }}
                                         environment : {{ strain.prelevement ? strain.prelevement.environment : "--" }}
+                                        bio-sample : {{ strain.prelevement and strain.prelevement.bioSample ? strain.prelevement.bioSample : "--" }}
+                                        farm-location : {{ strain.prelevement and strain.prelevement.farmLocation ? strain.prelevement.farmLocation : "--" }}
+
+                                        hospital-sample-type : {{ strain.prelevement and strain.prelevement.hospitalSampleType ? strain.prelevement.hospitalSampleType.value : "--" }}
+                                        hospital-site : {{ strain.prelevement and strain.prelevement.hospitalSite ? strain.prelevement.hospitalSite.value : "--" }}
+                                        hospital-ward : {{ strain.prelevement and strain.prelevement.hospitalWard ? strain.prelevement.hospitalWard : "--" }}
+
+                                        patient-context-type : {{ strain.prelevement and strain.prelevement.patientContextType ? strain.prelevement.patientContextType.value : "--" }}
+                                        source : {{ strain.prelevement and strain.prelevement.source ? strain.prelevement.source.value : "--" }}
                                     '>
                                 {{ strain.prelevement ? strain.prelevement.name : '--' }}
                             </td>

--- a/dev/templates/strain/main.html.twig
+++ b/dev/templates/strain/main.html.twig
@@ -46,24 +46,4 @@
         <br></br>        
         </div>  
 
-
- <script>
-        const toggleBtn = document.getElementById('toggleForm');
-        const formDiv = document.getElementById('form');
-        const closeBtn = document.getElementById('closeForm');
-
-        // Ouvrir le formulaire avec le bouton +
-        toggleBtn.addEventListener('click', () => {
-            formDiv.classList.remove('hidden');
-            formDiv.classList.add('show');
-            toggleBtn.style.display = 'none';
-        });
-
-        // Fermer le formulaire avec le bouton -
-        closeBtn.addEventListener('click', () => {
-            formDiv.classList.remove('show');
-            formDiv.classList.add('hidden');
-            toggleBtn.style.display = 'inline-block';
-        });
-</script>
 {% endblock %}

--- a/dev/templates/user/main.html.twig
+++ b/dev/templates/user/main.html.twig
@@ -3,15 +3,17 @@
 {% block body %}
     <div id="global">
         <div id="list">
-            <div id="filter">
+            <div id="filter" class="filterComponent">
                 {% include 'user/_filter_form_datatable_user.html.twig' %}
             </div>
             <div id="message">
                 {% include './message.html.twig' %}
             </div>
+            <div id="table-header-toolbar"></div>
             <div id="table" class="table-user">
                 {% include "user/list.html.twig" %}
             </div>
+            <div id="table-controls-footer"></div>
         </div>
         <br>
     </div>


### PR DESCRIPTION

Nous avons ajouté un système de prévisualisation des fichiers directement dans la table des strains afin d’éviter que certaines cellules deviennent trop grandes lorsque plusieurs fichiers sont associés à une même souche.

Dans les colonnes phenotype, sequencing et drugResistance, un bouton avec une icône œil a été ajouté. Lorsque l’utilisateur clique dessus, un modal s’ouvre et affiche l’ensemble des fichiers liés à cette strain. Les données sont récupérées dynamiquement via une requête AJAX sur la route /strain/{id}/file-preview/{type}.

Nous avons également adapté la logique d’affichage dans la table selon le type de données :

Pour drugResistance, toutes les résistances sont affichées directement dans la cellule. Cette information est importante à visualiser rapidement et ne génère généralement pas un grand nombre d’éléments.

Pour phenotype et sequencing, l’affichage est limité aux trois derniers éléments afin d’éviter que certaines cellules deviennent trop longues. Lorsque plus de trois fichiers existent, un indicateur +X more files est affiché pour signaler qu’il y a d’autres éléments disponibles.

La structure Twig des cellules a été réorganisée pour être plus claire. Chaque cellule contient désormais deux parties :

cell-header, qui contient le bouton permettant d’ouvrir le modal.

cell-content, qui affiche un aperçu des éléments visibles dans la table.

Nous avons également corrigé un conflit de clic qui existait entre le système de popup d’information (data-info) et le bouton du modal, et ajouté type="button" sur les boutons pour éviter toute soumission accidentelle du formulaire.

L’objectif global est de garder une table compacte et lisible tout en permettant d’accéder facilement aux informations complètes via le modal lorsque c’est nécessaire.