### PR TITLE
refactor measurement type et ajuste le CSS responsive

### DIFF
--- a/dev/assets/styles/app.css
+++ b/dev/assets/styles/app.css
@@ -217,14 +217,25 @@ input[type="checkbox"] {
 =========================================================== */
 
 #toggleForm {
-    width: 30px;
-    font-size: 20px;
+    width: 42px;
+    min-width: 42px;
+    max-width: 42px;
+    height: 92vh;
+    padding: 0;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    font-weight: bold;
+    font-family: "Roboto", sans-serif;
+    font-size: 18px;
+
     box-sizing: border-box;
     box-shadow: var(--shadow-soft);
-    border: 1px solid;
-    border-radius: 5px;
+    border: 1px solid var(--border-light);
+    border-radius: 6px;
     background-color: var(--bg-panel);
-    font-family: "Roboto", sans-serif;
     transition: all 0.3s ease;
 }
 
@@ -701,11 +712,13 @@ button.btn-form:hover,
 #global #list #table td.name {
     text-align: center;
     color: black;
-    width: 100px;
-    min-width: 100px;
-    max-width: 100px;
     font-weight: bold;
     background-color: #bdbdbd;
+
+    width: auto;
+    min-width: 150px;
+    max-width: none;
+
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -2388,7 +2401,7 @@ div.download-error {
 
     thead th:nth-child(2),
     tbody td:nth-child(2) {
-        left: 28px;
+        left: 27px !important;
         width: 48px !important;
         min-width: 48px !important;
         max-width: 48px !important;
@@ -2396,7 +2409,7 @@ div.download-error {
 
     thead th:nth-child(3),
     tbody td:nth-child(3) {
-        left: 76px; /* 28 + 48 */
+        left: 75px !important;
         width: 70px !important;
         min-width: 70px !important;
         max-width: 70px !important;
@@ -2411,7 +2424,7 @@ div.download-error {
 
     thead th:nth-last-child(2),
     tbody td:nth-last-child(2) {
-        right: 28px;
+        right: 27px !important;
         width: 48px !important;
         min-width: 48px !important;
         max-width: 48px !important;
@@ -2419,7 +2432,7 @@ div.download-error {
 
     thead th:nth-last-child(3),
     tbody td:nth-last-child(3) {
-        right: 76px; /* 28 + 48 */
+        right: 75px !important;
         width: 70px !important;
         min-width: 70px !important;
         max-width: 70px !important;
@@ -2434,10 +2447,11 @@ div.download-error {
 
     #left-toggles {
         order: 1;
-        width: 42px;
-        height: 92vh;
+        /* On passe en ligne et on élargit le container (42px * 2 + 8px de gap) */
+        width: 92px; 
+        height: auto; /* Hauteur auto car ils ne sont plus sur toute la colonne */
         display: flex;
-        flex-direction: column;
+        flex-direction: row; 
         gap: 8px;
         flex-shrink: 0;
         align-self: flex-start;
@@ -2446,23 +2460,24 @@ div.download-error {
     #left-toggles button,
     #toggleForm,
     #toggleTools {
-        flex: 1 1 0;
+        flex: 0 0 42px;
         width: 42px;
         min-width: 42px;
         max-width: 42px;
-        min-height: 0;
+        height: 42px; /* Optionnel : pour garder un aspect carré */
     }
 
+    /* Ajustement des autres éléments pour s'aligner sur la nouvelle largeur des toggles */
     #global #form {
         order: 2;
-        width: calc(50% - 8px);
-        max-width: calc(50% - 8px);
+        width: calc(100% - 100px); /* Ajusté pour laisser la place aux boutons à gauche */
+        max-width: calc(100% - 100px);
         max-height: 92vh;
     }
 
     #strain-tools {
         order: 3;
-        width: calc(50% - 8px);
+        width: 100%; /* Passe souvent en dessous si le formulaire prend toute la largeur restante */
         height: 92vh;
     }
 
@@ -2472,6 +2487,7 @@ div.download-error {
         flex: 0 0 100%;
     }
 }
+
 
 /* ===========================================================
    FINITIONS VISUELLES

--- a/dev/migrations/Version20260313140602.php
+++ b/dev/migrations/Version20260313140602.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260313140602 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Move measurement type from DrugResistance to DrugResistanceOnStrain';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // remove old column from drug
+        $this->addSql('ALTER TABLE drug_resistance DROP type');
+
+        // add measurement type to experiment result
+        $this->addSql('ALTER TABLE drug_resistance_on_strain ADD measurement_type VARCHAR(50) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // restore previous structure if rollback
+        $this->addSql('ALTER TABLE drug_resistance ADD type VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE drug_resistance_on_strain DROP measurement_type');
+    }
+}

--- a/dev/migrations/Version20260313144420.php
+++ b/dev/migrations/Version20260313144420.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260313144420 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE drug_resistance_on_strain CHANGE concentration concentration INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE drug_resistance_on_strain CHANGE concentration concentration INT NOT NULL');
+    }
+}

--- a/dev/src/Entity/DrugResistance.php
+++ b/dev/src/Entity/DrugResistance.php
@@ -20,9 +20,6 @@ class DrugResistance
     #[ORM\Column(length: 255)]
     private ?string $name = null;
 
-    #[ORM\Column(length: 255)]
-    private ?string $type = null;
-
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $description = null;
 
@@ -54,17 +51,6 @@ class DrugResistance
         return $this;
     }
 
-    public function getType(): ?string
-    {
-        return $this->type;
-    }
-
-    public function setType(string $type): static
-    {
-        $this->type = $type;
-
-        return $this;
-    }
 
     public function getDescription(): ?string
     {

--- a/dev/src/Entity/DrugResistanceOnStrain.php
+++ b/dev/src/Entity/DrugResistanceOnStrain.php
@@ -20,7 +20,7 @@ class DrugResistanceOnStrain
     #[ORM\ManyToOne(targetEntity: DrugResistance::class, inversedBy: 'drugResistanceOnStrains')]
     private ?DrugResistance $drugResistance;
 
-    #[ORM\Column]
+    #[ORM\Column(nullable: true)]
     private ?int $concentration = null;
 
     #[ORM\Column(length: 255, nullable: true)]
@@ -46,6 +46,9 @@ class DrugResistanceOnStrain
 
     #[ORM\Column(length: 50, nullable: true)]
     private ?string $concentrationUnit = null;
+
+    #[ORM\Column(length: 50)]
+    private ?string $measurementType = null;
 
     public function getId(): ?int
     {
@@ -167,6 +170,17 @@ class DrugResistanceOnStrain
     public function setConcentrationUnit(?string $unit): self
     {
         $this->concentrationUnit = $unit;
+        return $this;
+    }
+
+    public function getMeasurementType(): ?string
+    {
+        return $this->measurementType;
+    }
+
+    public function setMeasurementType(?string $measurementType): self
+    {
+        $this->measurementType = $measurementType;
         return $this;
     }
 

--- a/dev/src/Form/DrugFormType.php
+++ b/dev/src/Form/DrugFormType.php
@@ -14,12 +14,6 @@ class DrugFormType extends AbstractType
             ->add('name', options:[
                 'label' => 'Name Drug Resistance'
             ])
-            ->add('type', type: ChoiceType::class, options:[
-                'choices' => [
-                    'Quantitative' => 'quantitative',
-                    'Qualitative' => 'qualitative'
-                ]
-            ])
             ->add('description', options:[
                 'label' => 'Description'
             ])

--- a/dev/src/Form/DrugOnFormType.php
+++ b/dev/src/Form/DrugOnFormType.php
@@ -26,19 +26,24 @@ class DrugOnFormType extends AbstractType
                 'required' => true,
                 'label' => 'Drug',
             ])
+            ->add('measurementType', ChoiceType::class, [
+                'label' => 'Measurement type',
+                'choices' => [
+                    'Quantitative' => 'quantitative',
+                    'Qualitative' => 'qualitative',
+                ],
+                'placeholder' => 'Select type',
+                'required' => true,
+            ])
             ->add('concentration', options:[
                 'label' => 'Concentration',
                 'attr' => [
                     'placeholder' => 'Concentration',
                 ],
             ])
-            ->add('concentration', options:[
-                'label' => 'Concentration',
-                'attr' => ['placeholder' => 'Concentration'],
-            ])
             ->add('concentrationUnit', ChoiceType::class, [
                 'label' => 'Unit',
-                'required' => true, // ou false si tu veux
+                'required' => false, // ou false si tu veux
                 'placeholder' => 'Select unit',
                 'choices' => [
                     'µg/mL' => 'ug/mL',

--- a/dev/templates/drug/_form.html.twig
+++ b/dev/templates/drug/_form.html.twig
@@ -2,7 +2,6 @@
 {{ form_start(drugForm) }}
 
     {{ form_row(drugForm.name) }}
-    {{ form_row(drugForm.type) }}
     {{ form_row(drugForm.description) }}
     {{ form_row(drugForm.comment) }}
 

--- a/dev/templates/drug/list.html.twig
+++ b/dev/templates/drug/list.html.twig
@@ -30,7 +30,6 @@
                     <th><input type="checkbox" id="select-all" /></th>
                     <th>ID</th>
                     <th>Name</th>
-                    <th>Type</th>
                     <th>Description</th>
                     <th>Comment</th>
                     <th data-column="duplicate" class="no-sort"></th>
@@ -46,7 +45,6 @@
                     </td>
                     <td>{{ drug.id }}</td>
                     <td>{{ drug.name }}</td>
-                    <td>{{ drug.type }}</td>
                     <td data-info="{{ drug.description is not null ? drug.description : '--' }}">
                         {{ drug.description is not null ? drug.description : '--' }}
                     </td>

--- a/dev/templates/strain/_file_preview_cards.html.twig
+++ b/dev/templates/strain/_file_preview_cards.html.twig
@@ -17,6 +17,7 @@
                     <h4>{{ item.drugResistance ? item.drugResistance.name : '--' }}</h4>
 
                     <p><strong>Date :</strong> {{ item.date ? item.date|date('d/m/Y') : '--' }}</p>
+                    <p><strong>Measurement type :</strong> {{ item.measurementType ?: '--' }}</p>
                     <p><strong>Concentration :</strong> {{ item.concentration ?: '--' }}</p>
                     <p><strong>Concentration unit :</strong> {{ item.concentrationUnit ?: '--' }}</p>
                     <p><strong>Resistant :</strong> {{ item.resistant ? 'yes' : 'no' }}</p>

--- a/dev/templates/strain/_form.html.twig
+++ b/dev/templates/strain/_form.html.twig
@@ -618,3 +618,38 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 </script>
+
+<script>
+
+document.addEventListener('change', function(e) {
+
+    if (!e.target.name.includes('[measurementType]')) return;
+
+    const container = e.target.closest('li');
+    if (!container) return;
+
+    const concentration = container.querySelector('[name*="[concentration]"]');
+    const unit = container.querySelector('[name*="[concentrationUnit]"]');
+
+    if (e.target.value === 'qualitative') {
+
+        if (concentration) {
+            concentration.value = '';
+            concentration.disabled = true;
+        }
+
+        if (unit) {
+            unit.value = '';
+            unit.disabled = true;
+        }
+
+    } else {
+
+        if (concentration) concentration.disabled = false;
+        if (unit) unit.disabled = false;
+
+    }
+
+});
+
+</script>

--- a/dev/templates/strain/list.html.twig
+++ b/dev/templates/strain/list.html.twig
@@ -321,6 +321,7 @@
                                                 class="sub-cell drugResistanceOnStrain clicable"
                                                 data-info='
                                                     name: {{ item.drugResistance.name is defined ? item.drugResistance.name : "--" }}
+                                                    measurement_type: {{ item.measurementType is defined and item.measurementType ? item.measurementType : "--" }}
                                                     concentration: {{ item.concentration is defined and item.concentration ? item.concentration : "--" }}
                                                     concentration_unit: {{ item.concentrationUnit is defined and item.concentrationUnit ? item.concentrationUnit : "--" }}
                                                     date: {{ item.date is defined and item.date ? item.date|date("Y-m-d") : "--" }}


### PR DESCRIPTION
Refactorisation du système de mesure

Le modèle de mesure a été refactorisé afin de mieux séparer le type de mesure (MIC, qualitative, etc.), l’unité de concentration et la valeur mesurée.
Cette structure permet de gérer plus clairement les mesures quantitatives avec unité et les mesures qualitatives.

Mise à jour de la base de données

Deux migrations Doctrine ont été ajoutées pour adapter la base de données à cette nouvelle structure.
Elles modifient les champs liés aux mesures et harmonisent les types utilisés tout en conservant les données existantes.

Ajustements de l’interface

Quelques corrections CSS ont été réalisées pour maintenir un affichage cohérent après la refactorisation : alignement des champs liés aux mesures, corrections mineures dans les formulaires.

Responsive et affichage du tableau

Des ajustements CSS ont été ajoutés pour améliorer le responsive de la page Strain.
Le comportement du tableau a été corrigé sur écran réduit et les colonnes fixes gauche/droite ont été recalibrées pour éviter les décalages visuels.

Les boutons + (formulaire) et T (tools) ont également été rendus responsive : ils restent dans leur position normale sur grand écran et s’affichent côte à côte sur petit écran afin de réduire l’espace vertical utilisé.