### PR TITLE
fix: duplicate strain sur measurementType and concentrationUnit

### DIFF
--- a/dev/src/Controller/StrainController.php
+++ b/dev/src/Controller/StrainController.php
@@ -467,6 +467,8 @@ class StrainController extends AbstractController
                 $newDrug = new DrugResistanceOnStrain();
                 $newDrug->setDrugResistance($drug->getDrugResistance());
                 $newDrug->setConcentration($drug->getConcentration());
+                $newDrug->setConcentrationUnit($drug->getConcentrationUnit());
+                $newDrug->setMeasurementType($drug->getMeasurementType());
                 $newDrug->setDescription($drug->getDescription());
                 $newDrug->setComment($drug->getComment());
                 $newDrug->setResistant($drug->isResistant());


### PR DESCRIPTION
Correction de la duplication des souches après refactor du modèle de mesure.
Ajout de la copie des champs measurementType (obligatoire) et concentrationUnit dans DrugResistanceOnStrain afin d’éviter une erreur SQL lors du flush.